### PR TITLE
Added certificates manager with lru cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,24 +79,25 @@ The installation is easy. You can download the pre-built binaries for your platf
 
 This will display help for the tool. Here are all the switches it supports.
 
-| Flag                       | Description                | Example                                                      |
-| -------------------------- | -------------------------- | ------------------------------------------------------------ |
-| addr                       | Listen HTTP IP and Port    | proxify -addr 127.0.0.1:8080                                 |
-| dns-addr                   | Listen DNS IP and Port     | proxify -dns-addr '127.0.0.1:80'                             |
-| dns-mapping                | DNS A mapping              | proxify -dns-mapping test.com:80                             |
-| dns-resolver               | Listen DNS IP and Port     | proxify -dns-resolver '127.0.0.1:5353'                       |
-| http-proxy                 | Upstream HTTP Proxy        | proxify -http-proxy hxxp://127.0.0.1:8080                    |
-| no-color                   | No Color in output         | proxify -no-color                                            |
-| output                     | Output Folder              | proxify -output logs                                         |
-| request-dsl                | Request Filter DSL         | proxify -request-dsl "contains(request,'admim')"             |
-| request-match-replace-dsl  | Request Match-Replace DSL  | proxify -request-match-replace-dsl "replace(request,'false','true')" |
-| response-dsl               | Response Filter DSL        | proxify -response-dsl "contains(response, md5('test'))"      |
-| response-match-replace-dsl | Response Match-Replace DSL | proxify -response-match-replace-dsl "regex(response, '^authentication failed$', 'authentication ok')" |
-| silent                     | Silent output              | proxify -silent                                              |
-| socks5-proxy               | Upstream socks5 proxy      | proxify -socks5-proxy socks5://proxy-ip:port                 |
-| v                          | Verbose output             | proxify -v                                                   |
-| version                    | Current version            | proxify -version                                             |
-
+| Flag                       | Description                     | Example                                                                                               |
+|----------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------|
+| addr                       | Listen HTTP IP and Port         | proxify -addr 127.0.0.1:8080                                                                          |
+| directory                  | Directory to store program data | proxify -directory .custom/proxify                                                                    |
+| cert-cache-size            | Number of certificates to cache | proxify -cert-cache-size 1024                                                                         |
+| dns-addr                   | Listen DNS IP and Port          | proxify -dns-addr '127.0.0.1:80'                                                                      |
+| dns-mapping                | DNS A mapping                   | proxify -dns-mapping test.com:80                                                                      |
+| dns-resolver               | Listen DNS IP and Port          | proxify -dns-resolver '127.0.0.1:5353'                                                                |
+| http-proxy                 | Upstream HTTP Proxy             | proxify -http-proxy hxxp://127.0.0.1:8080                                                             |
+| no-color                   | No Color in output              | proxify -no-color                                                                                     |
+| output                     | Output Folder                   | proxify -output logs                                                                                  |
+| request-dsl                | Request Filter DSL              | proxify -request-dsl "contains(request,'admim')"                                                      |
+| request-match-replace-dsl  | Request Match-Replace DSL       | proxify -request-match-replace-dsl "replace(request,'false','true')"                                  |
+| response-dsl               | Response Filter DSL             | proxify -response-dsl "contains(response, md5('test'))"                                               |
+| response-match-replace-dsl | Response Match-Replace DSL      | proxify -response-match-replace-dsl "regex(response, '^authentication failed$', 'authentication ok')" |
+| silent                     | Silent output                   | proxify -silent                                                                                       |
+| socks5-proxy               | Upstream socks5 proxy           | proxify -socks5-proxy socks5://proxy-ip:port                                                          |
+| v                          | Verbose output                  | proxify -v                                                                                            |
+| version                    | Current version                 | proxify -version                                                                                      |
 
 
 ### Use Upstream proxy
@@ -160,7 +161,6 @@ Replay all the dumped requests/responses into the destination URL (http://127.0.
 ▶ replay -output "logs/"
 ```
 
-
 ### Applications of Proxify
 
 Proxify can be used for multiple places, here are some common example where Proxify comes handy:-
@@ -201,8 +201,12 @@ Start Chrome browser in Mac OS,
 /Applications/Chromium.app/Contents/MacOS/Chromium --ignore-certificate-errors --proxy-server=http://127.0.0.1:9999 &
 ```
 
-</details>
+A random certificate authority key is generated for proxify which is stored in the folder specified by `-directory` flag. The generated certificate can be imported by visiting [http://proxify/cacert.crt](http://proxify/cacert.crt) in a browser connected to proxify. 
 
+Installation steps for the Root Certificate is similar to other proxy tools which includes adding the cert to system trusted root store.
+
+
+</details>
 
 <details>
 <summary> Store all the response of while you fuzz as per you config at run time. </summary>
@@ -221,5 +225,6 @@ ffuf -x http://127.0.0.1:9999 FFUF_CMD_HERE
 ```
 
 </details>
+
 
 Proxify is made with 🖤 by the [projectdiscovery](https://projectdiscovery.io) team. Community contributions have made the project what it is. See the **[Thanks.md](https://github.com/projectdiscovery/proxify/blob/master/THANKS.md)** file for more details.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.14
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
 	github.com/elazarl/goproxy v0.0.0-20201021153353-00ad82a08272
+	github.com/hashicorp/golang-lru v0.5.4
+	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/dsl v0.0.2
 	github.com/projectdiscovery/fastdialer v0.0.2
 	github.com/projectdiscovery/gologger v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
@@ -18,6 +20,8 @@ github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectdiscovery/dsl v0.0.2 h1:7UysmR2d9CUbmNta8OFYA990FBlc/G7P6s7oNZL/kn4=
 github.com/projectdiscovery/dsl v0.0.2/go.mod h1:LMhpgZjWJ8NfZokFhzyu1blLWhUutCtNA9C6bH80WOo=

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -57,7 +57,7 @@ func ParseOptions() *Options {
 	flag.StringVar(&options.UpstreamSocks5Proxy, "socks5-proxy", "", "Upstream SOCKS5 Proxy (eg socks5://proxyip:proxyport")
 
 	flag.Parse()
-	os.MkdirAll(options.Directory, os.ModePerm)
+	_ = os.MkdirAll(options.Directory, os.ModePerm)
 
 	// Read the inputs and configure the logging
 	options.configureOutput()

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"flag"
 	"os"
+	"path"
 
 	"github.com/projectdiscovery/gologger"
 )
@@ -11,6 +12,8 @@ import (
 //nolint:maligned // used once
 type Options struct {
 	OutputDirectory         string
+	Directory               string
+	CertCacheSize           int
 	Verbose                 bool
 	Silent                  bool
 	Version                 bool
@@ -28,9 +31,17 @@ type Options struct {
 }
 
 func ParseOptions() *Options {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// Almost never here but panic
+		panic(err)
+	}
+
 	options := &Options{}
 	flag.StringVar(&options.OutputDirectory, "output", "logs", "Output Folder")
 	flag.BoolVar(&options.Verbose, "v", false, "Verbose")
+	flag.StringVar(&options.Directory, "directory", path.Join(homeDir, ".config", "proxify"), "Directory for storing program information")
+	flag.IntVar(&options.CertCacheSize, "cert-cache-size", 256, "Number of certificates to cache")
 	flag.BoolVar(&options.Silent, "silent", false, "Silent")
 	flag.BoolVar(&options.NoColor, "no-color", true, "No Color")
 	flag.BoolVar(&options.Version, "version", false, "Version")
@@ -46,6 +57,7 @@ func ParseOptions() *Options {
 	flag.StringVar(&options.UpstreamSocks5Proxy, "socks5-proxy", "", "Upstream SOCKS5 Proxy (eg socks5://proxyip:proxyport")
 
 	flag.Parse()
+	os.MkdirAll(options.Directory, os.ModePerm)
 
 	// Read the inputs and configure the logging
 	options.configureOutput()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,8 +15,10 @@ type Runner struct {
 
 // NewRunner instance
 func NewRunner(options *Options) (*Runner, error) {
-	proxy := proxify.NewProxy(&proxify.Options{
+	proxy, err := proxify.NewProxy(&proxify.Options{
 		Silent:                  options.Silent,
+		Directory:               options.Directory,
+		CertCacheSize:           options.CertCacheSize,
 		Verbose:                 options.Verbose,
 		ListenAddr:              options.ListenAddr,
 		OutputDirectory:         options.OutputDirectory,
@@ -30,6 +32,9 @@ func NewRunner(options *Options) (*Runner, error) {
 		RequestMatchReplaceDSL:  options.RequestMatchReplaceDSL,
 		ResponseMatchReplaceDSL: options.ResponseMatchReplaceDSL,
 	})
+	if err != nil {
+		return nil, err
+	}
 	return &Runner{options: options, proxy: proxy}, nil
 }
 

--- a/logger.go
+++ b/logger.go
@@ -16,9 +16,8 @@ type OptionsLogger struct {
 }
 
 type OutputData struct {
-	userdata   UserData
-	isResponse bool
-	data       []byte
+	userdata UserData
+	data     []byte
 }
 
 type Logger struct {
@@ -31,7 +30,7 @@ func NewLogger(options *OptionsLogger) *Logger {
 		options:    options,
 		asyncqueue: make(chan OutputData, 1000),
 	}
-	logger.createOutputFolder()
+	_ = logger.createOutputFolder()
 	go logger.AsyncWrite()
 	return logger
 }
@@ -40,7 +39,6 @@ func (l *Logger) createOutputFolder() error {
 	if l.options.OutputFolder == "" {
 		return nil
 	}
-
 	return os.MkdirAll(l.options.OutputFolder, 0755)
 }
 
@@ -59,7 +57,7 @@ func (l *Logger) AsyncWrite() {
 			if outputdata.userdata.match {
 				outputFileName = destFile + ".match.txt"
 			}
-			os.Rename(destFile, outputFileName)
+			_ = os.Rename(destFile, outputFileName)
 		}
 	}
 }
@@ -100,12 +98,4 @@ func (l *Logger) LogResponse(resp *http.Response, userdata UserData) error {
 
 func (l *Logger) Close() {
 	close(l.asyncqueue)
-}
-
-func fileExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
 }

--- a/pkg/certs/ca.go
+++ b/pkg/certs/ca.go
@@ -1,0 +1,153 @@
+package certs
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// Constants used for the SSL Certificates
+const (
+	bits          = 2048
+	organization  = "ProjectDiscovery, Inc."
+	country       = "IN"
+	province      = "Maharashtra"
+	locality      = "B.P.Lane"
+	streetAddress = "321, B.P.Lane West."
+	postalCode    = "400003"
+)
+
+// createCertificateAuthority creates a new certificate authority
+func (m *Manager) createAuthority(certPath, keyPath string) error {
+	priv, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Duration(365*24) * time.Hour)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization:  []string{organization},
+			Country:       []string{country},
+			Province:      []string{province},
+			Locality:      []string{locality},
+			StreetAddress: []string{streetAddress},
+			PostalCode:    []string{postalCode},
+			CommonName:    organization,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		return err
+	}
+	defer keyFile.Close()
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return err
+	}
+	defer certFile.Close()
+
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return err
+	}
+	return pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cert})
+}
+
+var errExpiredCert = errors.New("expired cert error")
+
+// readCertificateDisk reads a certificate and key file from disk
+func (m *Manager) readCertificateDisk(certFile string, keyFile string) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+	// Check the expiration.
+	if time.Now().After(cert.Leaf.NotAfter) {
+		return nil, errExpiredCert
+	}
+	return &cert, nil
+}
+
+// signCertificate signs a TLS Certificate for a host
+func (m *Manager) signCertificate(host string) (*tls.Certificate, error) {
+	x509ca, err := x509.ParseCertificate(m.cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Duration(365*24) * time.Hour)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Issuer:       x509ca.Subject,
+		Subject: pkix.Name{
+			Organization:  []string{organization},
+			Country:       []string{country},
+			Province:      []string{province},
+			Locality:      []string{locality},
+			StreetAddress: []string{streetAddress},
+			PostalCode:    []string{postalCode},
+			CommonName:    host,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	} else {
+		template.DNSNames = append(template.DNSNames, host)
+	}
+
+	certpriv, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, err
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, x509ca, &certpriv.PublicKey, m.cert.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Certificate{Certificate: [][]byte{derBytes, m.cert.Certificate[0]}, PrivateKey: certpriv}, nil
+}

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -73,7 +73,7 @@ retryRead:
 func (m *Manager) GetCA() (tls.Certificate, []byte) {
 	buffer := &bytes.Buffer{}
 
-	pem.Encode(buffer, &pem.Block{Type: "CERTIFICATE", Bytes: m.cert.Certificate[0]})
+	_ = pem.Encode(buffer, &pem.Block{Type: "CERTIFICATE", Bytes: m.cert.Certificate[0]})
 	return *m.cert, buffer.Bytes()
 }
 

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -1,0 +1,118 @@
+// Package certs implements a certificate signing authority implementation
+// to sign MITM'ed hosts certificates using a self-signed authority.
+//
+// It has uses an LRU-based certificate caching implementation for
+// caching the generated certificates for frequently accessed hosts.
+package certs
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/pem"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/elazarl/goproxy"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+)
+
+// Manager implements a certificate signing authority for TLS Mitm.
+type Manager struct {
+	cert  *tls.Certificate
+	cache *lru.Cache
+}
+
+// Options contains the configuration options for certificate signing client.
+type Options struct {
+	CacheSize int
+	Directory string
+}
+
+const (
+	caKeyName  = "cakey.pem"
+	caCertName = "cacert.pem"
+)
+
+// New creates a new certificate manager signing client instance
+func New(options *Options) (*Manager, error) {
+	manager := &Manager{}
+
+	certFile := path.Join(options.Directory, caCertName)
+	keyFile := path.Join(options.Directory, caKeyName)
+
+	_, certFileErr := os.Stat(certFile)
+	_, keyFileErr := os.Stat(keyFile)
+	if os.IsNotExist(certFileErr) || os.IsNotExist(keyFileErr) {
+		if err := manager.createAuthority(certFile, keyFile); err != nil {
+			return nil, errors.Wrap(err, "could not create certificate authority")
+		}
+	}
+retryRead:
+	cert, err := manager.readCertificateDisk(certFile, keyFile)
+	if err != nil {
+		// Check if we have an expired cert and regenerate
+		if err == errExpiredCert {
+			if err := manager.createAuthority(certFile, keyFile); err != nil {
+				return nil, errors.Wrap(err, "could not create certificate authority")
+			}
+			goto retryRead
+		}
+		return nil, errors.Wrap(err, "could not read certificate authority")
+	}
+
+	cache, err := lru.New(options.CacheSize)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create lru cache")
+	}
+	return &Manager{cert: cert, cache: cache}, nil
+}
+
+// GetCA returns the CA certificate in PEM Encoded format.
+func (m *Manager) GetCA() (tls.Certificate, []byte) {
+	buffer := &bytes.Buffer{}
+
+	pem.Encode(buffer, &pem.Block{Type: "CERTIFICATE", Bytes: m.cert.Certificate[0]})
+	return *m.cert, buffer.Bytes()
+}
+
+// Get returns a certificate for the current host.
+func (m *Manager) Get(host string) (*tls.Certificate, error) {
+	if value, ok := m.cache.Get(host); ok {
+		return value.(*tls.Certificate), nil
+	}
+	cert, err := m.signCertificate(host)
+	if err != nil {
+		return nil, err
+	}
+	m.cache.Add(host, cert)
+	return cert, nil
+}
+
+// TLSConfigFromCA generates a spoofed TLS certificate for a host
+func (m *Manager) TLSConfigFromCA() func(host string, ctx *goproxy.ProxyCtx) (*tls.Config, error) {
+	return func(host string, ctx *goproxy.ProxyCtx) (c *tls.Config, err error) {
+		hostname := stripPort(host)
+
+		value, ok := m.cache.Get(host)
+		if !ok {
+			certificate, err := m.signCertificate(hostname)
+			if err != nil {
+				return nil, err
+			}
+			value = certificate
+			m.cache.Add(host, certificate)
+		}
+
+		return &tls.Config{InsecureSkipVerify: true, Certificates: []tls.Certificate{*value.(*tls.Certificate)}}, nil
+	}
+}
+
+func stripPort(s string) string {
+	ix := strings.IndexRune(s, ':')
+	if ix == -1 {
+		return s
+	}
+	return s[:ix]
+}

--- a/proxy.go
+++ b/proxy.go
@@ -2,6 +2,7 @@ package proxify
 
 import (
 	"bufio"
+	"bytes"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/projectdiscovery/dsl"
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	"github.com/projectdiscovery/mapsutil"
+	"github.com/projectdiscovery/proxify/pkg/certs"
 	"github.com/projectdiscovery/tinydns"
 	"github.com/rs/xid"
 	"golang.org/x/net/proxy"
@@ -32,6 +34,8 @@ type OnConnectFunc func(string, *goproxy.ProxyCtx) (*goproxy.ConnectAction, stri
 type Options struct {
 	Silent                  bool
 	Verbose                 bool
+	CertCacheSize           int
+	Directory               string
 	ListenAddr              string
 	OutputDirectory         string
 	RequestDSL              string
@@ -52,6 +56,7 @@ type Proxy struct {
 	Dialer    *fastdialer.Dialer
 	options   *Options
 	logger    *Logger
+	certs     *certs.Manager
 	httpproxy *goproxy.ProxyHttpServer
 	tinydns   *tinydns.TinyDNS
 }
@@ -212,6 +217,32 @@ func (p *Proxy) Run() error {
 	p.httpproxy.OnRequest().HandleConnectFunc(onConnect)
 	p.httpproxy.OnRequest().DoFunc(onRequest)
 	p.httpproxy.OnResponse().DoFunc(onResponse)
+	p.httpproxy.OnRequest(goproxy.DstHostIs("proxify")).DoFunc(
+		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+			if r.URL.Path != "/cacert.crt" {
+				return r, goproxy.NewResponse(r, "text/plain", 404, "Invalid path given")
+			}
+
+			_, ca := p.certs.GetCA()
+			reader := bytes.NewReader(ca)
+
+			header := http.Header{}
+			header.Set("Content-Type", "application/pkix-cert")
+			resp := &http.Response{
+				Request:          r,
+				TransferEncoding: r.TransferEncoding,
+				Header:           header,
+				StatusCode:       200,
+				Status:           http.StatusText(200),
+				ContentLength:    int64(reader.Len()),
+				Body:             ioutil.NopCloser(reader),
+			}
+			return r, resp
+		},
+	)
+	// Serve the certificate when the user makes requests to /proxify
+	http.HandleFunc("/proxify", func(w http.ResponseWriter, r *http.Request) {
+	})
 	return http.ListenAndServe(p.options.ListenAddr, p.httpproxy)
 }
 
@@ -219,13 +250,30 @@ func (p *Proxy) Stop() {
 
 }
 
-func NewProxy(options *Options) *Proxy {
+func NewProxy(options *Options) (*Proxy, error) {
+	certs, err := certs.New(&certs.Options{
+		CacheSize: options.CertCacheSize,
+		Directory: options.Directory,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	httpproxy := goproxy.NewProxyHttpServer()
 	if options.Silent {
 		httpproxy.Logger = log.New(ioutil.Discard, "", log.Ltime|log.Lshortfile)
 	} else {
 		httpproxy.Verbose = true
 	}
+	httpproxy.Verbose = false
+
+	ca, _ := certs.GetCA()
+	goproxy.GoproxyCa = ca
+	goproxy.OkConnect = &goproxy.ConnectAction{Action: goproxy.ConnectAccept, TLSConfig: certs.TLSConfigFromCA()}
+	goproxy.MitmConnect = &goproxy.ConnectAction{Action: goproxy.ConnectMitm, TLSConfig: certs.TLSConfigFromCA()}
+	goproxy.HTTPMitmConnect = &goproxy.ConnectAction{Action: goproxy.ConnectHTTPMitm, TLSConfig: certs.TLSConfigFromCA()}
+	goproxy.RejectConnect = &goproxy.ConnectAction{Action: goproxy.ConnectReject, TLSConfig: certs.TLSConfigFromCA()}
+
 	logger := NewLogger(&OptionsLogger{
 		Verbose:      options.Verbose,
 		OutputFolder: options.OutputDirectory,
@@ -253,7 +301,7 @@ func NewProxy(options *Options) *Proxy {
 	}
 	dialer, err := fastdialer.NewDialer(fastdialerOptions)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return &Proxy{httpproxy: httpproxy, logger: logger, options: options, Dialer: dialer, tinydns: tdns}
+	return &Proxy{httpproxy: httpproxy, certs: certs, logger: logger, options: options, Dialer: dialer, tinydns: tdns}, nil
 }


### PR DESCRIPTION
This PR adds a certificates manager implementation which allows self-signed certificates that are stored in user's directory and can also be installed in a proxy instance by going to url [http://proxify/cacert.crt](http://proxify/cacert.crt).

The generated certificates are cached per host using an LRU cache that evicts older items keeping only the most frequently accessed certificate in store.