### PR TITLE
Fixes overwrite of ES options

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -49,10 +49,7 @@ func NewLogger(options *OptionsLogger) *Logger {
 		asyncqueue: make(chan types.OutputData, 1000),
 	}
 	if options.Elastic.Addr != "" {
-		store, err := elastic.New(&elastic.Options{
-			Addr:      options.Elastic.Addr,
-			IndexName: options.Elastic.IndexName,
-		})
+		store, err := elastic.New(options.Elastic)
 		if err != nil {
 			gologger.Warning().Msgf("Error while creating elastic logger: %s", err)
 		} else {


### PR DESCRIPTION
## Proposed changes

Currently, logger.go overwrites most user provided CLI ElasticSearch options. To test set "-elastic-ssl", "-elastic-username", or "-elastic-password" and notice these are not sent to the ElasticSearch cluster. The issue is on line 52-55 of logger.go which take in two user provided options but ignore the rest. This PR fixes that by including all supplied ES options. This behaved correctly on a ES server I tested against.

## Checklist

I am not sure how to run the checks. Any help with that would be great. Thank you!

- [X ] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have added necessary documentation (if appropriate)