### PR TITLE
Add support for -vv flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ CONFIGURATION:
    -deny string          Denied list of IP/CIDR's to be proxied
 
 DEBUG:
-   -silent         Silent
-   -nc, -no-color  No Color (default true)
-   -version        Version
-   -v, -verbose    Verbose
+   -silent              Silent
+   -nc, -no-color       No Color (default true)
+   -version             Version
+   -v, -verbose         Verbose
+   -vv, -very-verbose   Very Verbose
 ```
 
 ### Running Proxify

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	Directory                   string
 	CertCacheSize               int
 	Verbose                     bool
+	VeryVerbose                 bool
 	Silent                      bool
 	Version                     bool
 	ListenAddrHTTP              string
@@ -105,6 +106,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", true, "No Color"),
 		flagSet.BoolVar(&options.Version, "version", false, "Version"),
 		flagSet.BoolVarP(&options.Verbose, "verbose", "v", false, "Verbose"),
+		flagSet.BoolVarP(&options.VeryVerbose, "very-verbose", "vv", false, "Very Verbose"),
 	)
 
 	_ = flagSet.Parse()
@@ -125,7 +127,7 @@ func ParseOptions() *Options {
 }
 
 func (options *Options) configureOutput() {
-	if options.Verbose {
+	if options.Verbose || options.VeryVerbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)
 	}
 	if options.NoColor {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -20,6 +20,7 @@ func NewRunner(options *Options) (*Runner, error) {
 		Directory:                   options.Directory,
 		CertCacheSize:               options.CertCacheSize,
 		Verbose:                     options.Verbose,
+		VeryVerbose:                 options.VeryVerbose,
 		ListenAddrHTTP:              options.ListenAddrHTTP,
 		ListenAddrSocks5:            options.ListenAddrSocks5,
 		OutputDirectory:             options.OutputDirectory,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,6 +25,7 @@ const (
 
 type OptionsLogger struct {
 	Verbose      bool
+	VeryVerbose  bool
 	OutputFolder string
 	DumpRequest  bool
 	DumpResponse bool
@@ -135,7 +136,7 @@ func (l *Logger) LogRequest(req *http.Request, userdata types.UserData) error {
 		l.asyncqueue <- types.OutputData{Data: reqdump, Userdata: userdata}
 	}
 
-	if l.options.Verbose {
+	if l.options.VeryVerbose {
 		contentType := req.Header.Get("Content-Type")
 		b, _ := ioutil.ReadAll(req.Body)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(b)) {
@@ -166,7 +167,7 @@ func (l *Logger) LogResponse(resp *http.Response, userdata types.UserData) error
 	if l.options.OutputFolder != "" || l.options.Kafka.Addr != "" || l.options.Elastic.Addr != "" {
 		l.asyncqueue <- types.OutputData{Data: respdump, Userdata: userdata}
 	}
-	if l.options.Verbose {
+	if l.options.VeryVerbose {
 		contentType := resp.Header.Get("Content-Type")
 		bodyBytes := bytes.TrimPrefix(respdump, respdumpNoBody)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(bodyBytes)) {

--- a/proxy.go
+++ b/proxy.go
@@ -44,6 +44,7 @@ type Options struct {
 	DumpResponse                bool
 	Silent                      bool
 	Verbose                     bool
+	VeryVerbose                 bool
 	CertCacheSize               int
 	Directory                   string
 	ListenAddrHTTP              string
@@ -331,7 +332,7 @@ func NewProxy(options *Options) (*Proxy, error) {
 		httpproxy = goproxy.NewProxyHttpServer()
 		if options.Silent {
 			httpproxy.Logger = log.New(ioutil.Discard, "", log.Ltime|log.Lshortfile)
-		} else if options.Verbose {
+		} else if options.Verbose || options.VeryVerbose {
 			httpproxy.Verbose = true
 		} else {
 			httpproxy.Verbose = false
@@ -347,6 +348,7 @@ func NewProxy(options *Options) (*Proxy, error) {
 
 	logger := logger.NewLogger(&logger.OptionsLogger{
 		Verbose:      options.Verbose,
+		VeryVerbose:  options.VeryVerbose,
 		OutputFolder: options.OutputDirectory,
 		DumpRequest:  options.DumpRequest,
 		DumpResponse: options.DumpResponse,

--- a/socket.go
+++ b/socket.go
@@ -31,6 +31,7 @@ type SocketConn struct {
 	sentBytes               uint64
 	receivedBytes           uint64
 	Verbose                 bool
+	VeryVerbose             bool
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string
@@ -52,6 +53,7 @@ type SocketProxyOptions struct {
 	TLSServerConfig         *tls.Config
 	TLSServer               bool
 	Verbose                 bool
+	VeryVerbose             bool
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string
@@ -108,7 +110,7 @@ func (p *SocketProxy) Run() error {
 			log.Println(err)
 			return err
 		}
-		go p.Proxy(conn)  //nolint
+		go p.Proxy(conn) //nolint
 	}
 }
 
@@ -120,6 +122,7 @@ func (p *SocketProxy) Proxy(conn net.Conn) error {
 
 	socketConn.Timeout = p.options.Timeout
 	socketConn.Verbose = p.options.Verbose
+	socketConn.VeryVerbose = p.options.VeryVerbose
 	socketConn.OutputHex = p.options.OutputHex
 
 	socketConn.lconn = conn


### PR DESCRIPTION
## Proposed changes

<!--
Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request.
-->

This PR implements the -vv flag as described in https://github.com/projectdiscovery/proxify/issues/139.

Currently there is only `-v` flag which shows the whole request and response body. The `-vv` flag is added and divides logging levels into two. The `-v` flag only shows request and response type, and the `-vv` flag also shows the response body. The `-vv` flag implicitly includes `-v`.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)