### PR TITLE
Combine verbosity-related bool flags into single enum member variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ CONFIGURATION:
    -deny string          Denied list of IP/CIDR's to be proxied
 
 DEBUG:
-   -silent              Silent
    -nc, -no-color       No Color (default true)
    -version             Version
+   -silent              Silent
    -v, -verbose         Verbose
    -vv, -very-verbose   Very Verbose
 ```

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/proxify/pkg/logger/elastic"
 	"github.com/projectdiscovery/proxify/pkg/logger/kafka"
+	"github.com/projectdiscovery/proxify/pkg/types"
 )
 
 // Options of the runner
@@ -17,7 +18,7 @@ type Options struct {
 	OutputDirectory             string
 	Directory                   string
 	CertCacheSize               int
-	Verbosity                   int // 0: silent, 1: default, 2: verbose, 3: very verbose
+	Verbosity                   types.Verbosity
 	Version                     bool
 	ListenAddrHTTP              string
 	ListenAddrSocks5            string
@@ -133,20 +134,20 @@ func (options *Options) configureVerbosity(silent, verbose, veryVerbose bool) {
 	}
 
 	if silent {
-		options.Verbosity = 0
+		options.Verbosity = types.VerbositySilent
 	} else if veryVerbose {
-		options.Verbosity = 3
+		options.Verbosity = types.VerbosityVeryVerbose
 	} else if verbose {
-		options.Verbosity = 2
+		options.Verbosity = types.VerbosityVerbose
 	} else {
-		options.Verbosity = 1
+		options.Verbosity = types.VerbosityDefault
 	}
 }
 
 func (options *Options) configureOutput() {
-	if options.Verbosity <= 0 {
+	if options.Verbosity <= types.VerbositySilent {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)
-	} else if options.Verbosity >= 2 {
+	} else if options.Verbosity >= types.VerbosityVerbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)
 	}
 	if options.NoColor {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,11 +16,9 @@ type Runner struct {
 // NewRunner instance
 func NewRunner(options *Options) (*Runner, error) {
 	proxy, err := proxify.NewProxy(&proxify.Options{
-		Silent:                      options.Silent,
 		Directory:                   options.Directory,
 		CertCacheSize:               options.CertCacheSize,
-		Verbose:                     options.Verbose,
-		VeryVerbose:                 options.VeryVerbose,
+		Verbosity:                   options.Verbosity,
 		ListenAddrHTTP:              options.ListenAddrHTTP,
 		ListenAddrSocks5:            options.ListenAddrSocks5,
 		OutputDirectory:             options.OutputDirectory,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -24,7 +24,7 @@ const (
 )
 
 type OptionsLogger struct {
-	Verbosity    int // 0: silent, 1: default, 2: verbose, 3: very verbose
+	Verbosity    types.Verbosity
 	OutputFolder string
 	DumpRequest  bool
 	DumpResponse bool
@@ -132,7 +132,7 @@ func (l *Logger) LogRequest(req *http.Request, userdata types.UserData) error {
 		l.asyncqueue <- types.OutputData{Data: reqdump, Userdata: userdata}
 	}
 
-	if l.options.Verbosity >= 3 {
+	if l.options.Verbosity >= types.VerbosityVeryVerbose {
 		contentType := req.Header.Get("Content-Type")
 		b, _ := ioutil.ReadAll(req.Body)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(b)) {
@@ -163,7 +163,7 @@ func (l *Logger) LogResponse(resp *http.Response, userdata types.UserData) error
 	if l.options.OutputFolder != "" || l.options.Kafka.Addr != "" || l.options.Elastic.Addr != "" {
 		l.asyncqueue <- types.OutputData{Data: respdump, Userdata: userdata}
 	}
-	if l.options.Verbosity >= 3 {
+	if l.options.Verbosity >= types.VerbosityVeryVerbose {
 		contentType := resp.Header.Get("Content-Type")
 		bodyBytes := bytes.TrimPrefix(respdump, respdumpNoBody)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(bodyBytes)) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -24,8 +24,7 @@ const (
 )
 
 type OptionsLogger struct {
-	Verbose      bool
-	VeryVerbose  bool
+	Verbosity    int // 0: silent, 1: default, 2: verbose, 3: very verbose
 	OutputFolder string
 	DumpRequest  bool
 	DumpResponse bool
@@ -133,7 +132,7 @@ func (l *Logger) LogRequest(req *http.Request, userdata types.UserData) error {
 		l.asyncqueue <- types.OutputData{Data: reqdump, Userdata: userdata}
 	}
 
-	if l.options.VeryVerbose {
+	if l.options.Verbosity >= 3 {
 		contentType := req.Header.Get("Content-Type")
 		b, _ := ioutil.ReadAll(req.Body)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(b)) {
@@ -164,7 +163,7 @@ func (l *Logger) LogResponse(resp *http.Response, userdata types.UserData) error
 	if l.options.OutputFolder != "" || l.options.Kafka.Addr != "" || l.options.Elastic.Addr != "" {
 		l.asyncqueue <- types.OutputData{Data: respdump, Userdata: userdata}
 	}
-	if l.options.VeryVerbose {
+	if l.options.Verbosity >= 3 {
 		contentType := resp.Header.Get("Content-Type")
 		bodyBytes := bytes.TrimPrefix(respdump, respdumpNoBody)
 		if isASCIICheckRequired(contentType) && !govalidator.IsPrintableASCII(string(bodyBytes)) {

--- a/pkg/types/verbosity.go
+++ b/pkg/types/verbosity.go
@@ -1,0 +1,10 @@
+package types
+
+type Verbosity int
+
+const (
+	VerbositySilent Verbosity = iota
+	VerbosityDefault
+	VerbosityVerbose
+	VerbosityVeryVerbose
+)

--- a/proxy.go
+++ b/proxy.go
@@ -42,7 +42,7 @@ type OnConnectFunc func(string, *goproxy.ProxyCtx) (*goproxy.ConnectAction, stri
 type Options struct {
 	DumpRequest                 bool
 	DumpResponse                bool
-	Verbosity                   int // 0: silent, 1: default, 2: verbose, 3: very verbose
+	Verbosity                   types.Verbosity
 	CertCacheSize               int
 	Directory                   string
 	ListenAddrHTTP              string
@@ -328,9 +328,9 @@ func NewProxy(options *Options) (*Proxy, error) {
 	var httpproxy *goproxy.ProxyHttpServer
 	if options.ListenAddrHTTP != "" {
 		httpproxy = goproxy.NewProxyHttpServer()
-		if options.Verbosity <= 0 {
+		if options.Verbosity <= types.VerbositySilent {
 			httpproxy.Logger = log.New(ioutil.Discard, "", log.Ltime|log.Lshortfile)
-		} else if options.Verbosity >= 2 {
+		} else if options.Verbosity >= types.VerbosityVerbose {
 			httpproxy.Verbose = true
 		} else {
 			httpproxy.Verbose = false
@@ -411,7 +411,7 @@ func NewProxy(options *Options) (*Proxy, error) {
 		socks5Config := &socks5.Config{
 			Dial: proxy.httpTunnelDialer,
 		}
-		if options.Verbosity <= 0 {
+		if options.Verbosity <= types.VerbositySilent {
 			socks5Config.Logger = log.New(ioutil.Discard, "", log.Ltime|log.Lshortfile)
 		}
 		socks5proxy, err = socks5.New(socks5Config)

--- a/socket.go
+++ b/socket.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/dsl"
+	"github.com/projectdiscovery/proxify/pkg/types"
 )
 
 // SocketProxy - connect two sockets with TLS inspection
@@ -30,7 +31,7 @@ type SocketConn struct {
 	HTTPServer              string
 	sentBytes               uint64
 	receivedBytes           uint64
-	Verbosity               int
+	Verbosity               types.Verbosity
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string
@@ -51,7 +52,7 @@ type SocketProxyOptions struct {
 	TLSClient               bool
 	TLSServerConfig         *tls.Config
 	TLSServer               bool
-	Verbosity               int
+	Verbosity               types.Verbosity
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string

--- a/socket.go
+++ b/socket.go
@@ -30,8 +30,7 @@ type SocketConn struct {
 	HTTPServer              string
 	sentBytes               uint64
 	receivedBytes           uint64
-	Verbose                 bool
-	VeryVerbose             bool
+	Verbosity               int
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string
@@ -52,8 +51,7 @@ type SocketProxyOptions struct {
 	TLSClient               bool
 	TLSServerConfig         *tls.Config
 	TLSServer               bool
-	Verbose                 bool
-	VeryVerbose             bool
+	Verbosity               int
 	OutputHex               bool
 	Timeout                 time.Duration
 	RequestMatchReplaceDSL  string
@@ -121,8 +119,7 @@ func (p *SocketProxy) Proxy(conn net.Conn) error {
 	)
 
 	socketConn.Timeout = p.options.Timeout
-	socketConn.Verbose = p.options.Verbose
-	socketConn.VeryVerbose = p.options.VeryVerbose
+	socketConn.Verbosity = p.options.Verbosity
 	socketConn.OutputHex = p.options.OutputHex
 
 	socketConn.lconn = conn


### PR DESCRIPTION
## Proposed changes

<!--
Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request.
-->

Previously, there were 3 different bool flags related to verbosity. Having many member variables for values that should be mutually exclusive led to a bug where contradicting flags could be set. This caused unexpected behavior with regards to logging.

This commit combines the bool flags into 1 enum flag. As a result, verbosity level is guaranteed to be mutually exclusive. This commit also adds validation of the verbosity flags and exits with an error msg.

This PR resolves #146.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)