### PR TITLE
Excluding windows arm/arm64 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,11 @@ builds:
         - 386
         - arm
         - arm64
+      ignore:
+        - goos: windows
+          goarch: 'arm'
+        - goos: windows
+          goarch: 'arm64'
       id: proxify
 
     - binary: replay
@@ -27,6 +32,11 @@ builds:
         - 386
         - arm
         - arm64
+      ignore:
+        - goos: windows
+          goarch: 'arm'
+        - goos: windows
+          goarch: 'arm64'
       id: replay
 
     - binary: mitmrelay
@@ -40,6 +50,11 @@ builds:
         - 386
         - arm
         - arm64
+      ignore:
+        - goos: windows
+          goarch: 'arm'
+        - goos: windows
+          goarch: 'arm64'
       id: mitmrelay
 
 archives:


### PR DESCRIPTION
## Proposed changes
This PR excludes windows arm/arm64 from goreleaser until https://github.com/projectdiscovery/hmap/issues/45 is fixed

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)