### PR TITLE
replay: remove hardcoded listen address

### DIFF
--- a/cmd/replay/replay.go
+++ b/cmd/replay/replay.go
@@ -85,7 +85,7 @@ func main() {
 		io.Copy(w, response.Body) //nolint
 	})
 	go func() {
-		if err := http.ListenAndServe(":80", nil); err != nil {
+		if err := http.ListenAndServe(options.HTTPListenerAddress, nil); err != nil {
 			gologger.Fatal().Msgf("Could not listen and serve: %s\n", err)
 		}
 	}()


### PR DESCRIPTION
## Proposed changes

- Value of `-http-addr` is used instead of hardcoded ":80" as http listen address

closes #195 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)