### PR TITLE
Match Multiple DSLs

### DIFF
--- a/cmd/mitmrelay/mitmrelay.go
+++ b/cmd/mitmrelay/mitmrelay.go
@@ -110,8 +110,8 @@ func main() {
 	}
 	proxyOpts.Protocol = options.Protocol
 	proxyOpts.HTTPProxy = options.HTTPProxy
-	proxyOpts.RequestMatchReplaceDSL = options.RequestMatchReplaceDSL
-	proxyOpts.ResponseMatchReplaceDSL = options.ResponseMatchReplaceDSL
+	proxyOpts.RequestMatchReplaceDSL = []string{options.RequestMatchReplaceDSL}
+	proxyOpts.ResponseMatchReplaceDSL = []string{options.ResponseMatchReplaceDSL}
 
 	if options.Timeout >= 0 {
 		proxyOpts.Timeout = time.Duration(options.Timeout) * time.Second

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -27,9 +27,9 @@ type Options struct {
 	DNSFallbackResolver         string              // Listen DNS Ip and port (ip:port)
 	NoColor                     bool                // No Color
 	RequestDSL                  goflags.StringSlice // Request Filter DSL
-	RequestMatchReplaceDSL      string              // Request Match-Replace DSL
+	RequestMatchReplaceDSL      goflags.StringSlice // Request Match-Replace DSL
 	ResponseDSL                 goflags.StringSlice // Response Filter DSL
-	ResponseMatchReplaceDSL     string              // Request Match-Replace DSL
+	ResponseMatchReplaceDSL     goflags.StringSlice // Request Match-Replace DSL
 	UpstreamHTTPProxies         goflags.StringSlice // Upstream HTTP comma separated Proxies (e.g. http://proxyip:proxyport)
 	UpstreamSocks5Proxies       goflags.StringSlice // Upstream SOCKS5 comma separated Proxies (e.g. socks5://proxyip:proxyport)
 	UpstreamProxyRequestsNumber int                 // Number of requests before switching upstream proxy
@@ -63,8 +63,8 @@ func ParseOptions() *Options {
 	createGroup(flagSet, "filter", "Filter",
 		flagSet.StringSliceVarP(&options.RequestDSL, "request-dsl", "req-fd", nil, "Request Filter DSL", goflags.StringSliceOptions),
 		flagSet.StringSliceVarP(&options.ResponseDSL, "response-dsl", "resp-fd", nil, "Response Filter DSL", goflags.StringSliceOptions),
-		flagSet.StringVarP(&options.RequestMatchReplaceDSL, "request-match-replace-dsl", "req-mrd", "", "Request Match-Replace DSL"),
-		flagSet.StringVarP(&options.ResponseMatchReplaceDSL, "response-match-replace-dsl", "resp-mrd", "", "Response Match-Replace DSL"),
+		flagSet.StringSliceVarP(&options.RequestMatchReplaceDSL, "request-match-replace-dsl", "req-mrd", nil, "Request Match-Replace DSL", goflags.StringSliceOptions),
+		flagSet.StringSliceVarP(&options.ResponseMatchReplaceDSL, "response-match-replace-dsl", "resp-mrd", nil, "Response Match-Replace DSL", goflags.StringSliceOptions),
 	)
 
 	createGroup(flagSet, "network", "Network",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -26,9 +26,9 @@ type Options struct {
 	DNSMapping                  string              // DNSMapping contains user provided hosts
 	DNSFallbackResolver         string              // Listen DNS Ip and port (ip:port)
 	NoColor                     bool                // No Color
-	RequestDSL                  string              // Request Filter DSL
+	RequestDSL                  goflags.StringSlice // Request Filter DSL
 	RequestMatchReplaceDSL      string              // Request Match-Replace DSL
-	ResponseDSL                 string              // Response Filter DSL
+	ResponseDSL                 goflags.StringSlice // Response Filter DSL
 	ResponseMatchReplaceDSL     string              // Request Match-Replace DSL
 	UpstreamHTTPProxies         goflags.StringSlice // Upstream HTTP comma separated Proxies (e.g. http://proxyip:proxyport)
 	UpstreamSocks5Proxies       goflags.StringSlice // Upstream SOCKS5 comma separated Proxies (e.g. socks5://proxyip:proxyport)
@@ -61,8 +61,8 @@ func ParseOptions() *Options {
 	)
 
 	createGroup(flagSet, "filter", "Filter",
-		flagSet.StringVarP(&options.RequestDSL, "request-dsl", "req-fd", "", "Request Filter DSL"),
-		flagSet.StringVarP(&options.ResponseDSL, "response-dsl", "resp-fd", "", "Response Filter DSL"),
+		flagSet.StringSliceVarP(&options.RequestDSL, "request-dsl", "req-fd", nil, "Request Filter DSL", goflags.StringSliceOptions),
+		flagSet.StringSliceVarP(&options.ResponseDSL, "response-dsl", "resp-fd", nil, "Response Filter DSL", goflags.StringSliceOptions),
 		flagSet.StringVarP(&options.RequestMatchReplaceDSL, "request-match-replace-dsl", "req-mrd", "", "Request Match-Replace DSL"),
 		flagSet.StringVarP(&options.ResponseMatchReplaceDSL, "response-match-replace-dsl", "resp-mrd", "", "Response Match-Replace DSL"),
 	)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -47,35 +47,22 @@ func NewRunner(options *Options) (*Runner, error) {
 	return &Runner{options: options, proxy: proxy}, nil
 }
 
+func (r *Runner) validateExpressions(expressionsGroups ...[]string) error {
+	for _, expressionsGroup := range expressionsGroups {
+		for _, expression := range expressionsGroup {
+			if _, err := govaluate.NewEvaluableExpressionWithFunctions(expression, dsl.DefaultHelperFunctions); err != nil {
+				printDslCompileError(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Run polling and notification
 func (r *Runner) Run() error {
-	for i := 0; i < len(r.options.RequestDSL); i++ {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestDSL[i], dsl.DefaultHelperFunctions)
-		if err != nil {
-			printDslCompileError(err)
-			return err
-		}
-	}
-	for i := 0; i < len(r.options.ResponseDSL); i++ {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseDSL[i], dsl.DefaultHelperFunctions)
-		if err != nil {
-			printDslCompileError(err)
-			return err
-		}
-	}
-	for i := 0; i < len(r.options.RequestMatchReplaceDSL); i++ {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestMatchReplaceDSL[i], dsl.DefaultHelperFunctions)
-		if err != nil {
-			printDslCompileError(err)
-			return err
-		}
-	}
-	for i := 0; i < len(r.options.ResponseMatchReplaceDSL); i++ {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseMatchReplaceDSL[i], dsl.DefaultHelperFunctions)
-		if err != nil {
-			printDslCompileError(err)
-			return err
-		}
+	if err := r.validateExpressions(r.options.RequestDSL, r.options.ResponseDSL, r.options.RequestMatchReplaceDSL, r.options.ResponseMatchReplaceDSL); err != nil {
+		return err
 	}
 
 	// configuration summary

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -63,15 +63,15 @@ func (r *Runner) Run() error {
 			return err
 		}
 	}
-	if r.options.RequestMatchReplaceDSL != "" {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestMatchReplaceDSL, dsl.DefaultHelperFunctions)
+	for i := 0; i < len(r.options.RequestMatchReplaceDSL); i++ {
+		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestMatchReplaceDSL[i], dsl.DefaultHelperFunctions)
 		if err != nil {
 			printDslCompileError(err)
 			return err
 		}
 	}
-	if r.options.ResponseMatchReplaceDSL != "" {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseMatchReplaceDSL, dsl.DefaultHelperFunctions)
+	for i := 0; i < len(r.options.ResponseMatchReplaceDSL); i++ {
+		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseMatchReplaceDSL[i], dsl.DefaultHelperFunctions)
 		if err != nil {
 			printDslCompileError(err)
 			return err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -49,15 +49,15 @@ func NewRunner(options *Options) (*Runner, error) {
 
 // Run polling and notification
 func (r *Runner) Run() error {
-	if r.options.RequestDSL != "" {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestDSL, dsl.DefaultHelperFunctions)
+	for i := 0; i < len(r.options.RequestDSL); i++ {
+		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.RequestDSL[i], dsl.DefaultHelperFunctions)
 		if err != nil {
 			printDslCompileError(err)
 			return err
 		}
 	}
-	if r.options.ResponseDSL != "" {
-		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseDSL, dsl.DefaultHelperFunctions)
+	for i := 0; i < len(r.options.ResponseDSL); i++ {
+		_, err := govaluate.NewEvaluableExpressionWithFunctions(r.options.ResponseDSL[i], dsl.DefaultHelperFunctions)
 		if err != nil {
 			printDslCompileError(err)
 			return err

--- a/proxy.go
+++ b/proxy.go
@@ -91,10 +91,10 @@ func (p *Proxy) OnRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 	}
 
 	// check dsl
-	for i := 0; i < len(p.options.RequestDSL); i++ {
+	for _, expr := range p.options.RequestDSL {
 		if !userdata.Match {
 			m, _ := util.HTTPRequesToMap(req)
-			v, err := dsl.EvalExpr(p.options.RequestDSL[i], m)
+			v, err := dsl.EvalExpr(expr, m)
 			if err != nil {
 				gologger.Warning().Msgf("Could not evaluate request dsl: %s\n", err)
 			}
@@ -119,10 +119,10 @@ func (p *Proxy) OnRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 func (p *Proxy) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 	userdata := ctx.UserData.(types.UserData)
 	userdata.HasResponse = true
-	for i := 0; i < len(p.options.ResponseDSL); i++ {
+	for _, expr := range p.options.ResponseDSL {
 		if !userdata.Match {
 			m, _ := util.HTTPResponseToMap(resp)
-			v, err := dsl.EvalExpr(p.options.ResponseDSL[i], m)
+			v, err := dsl.EvalExpr(expr, m)
 			if err != nil {
 				gologger.Warning().Msgf("Could not evaluate response dsl: %s\n", err)
 			}
@@ -161,8 +161,8 @@ func (p *Proxy) MatchReplaceRequest(req *http.Request) error {
 	// lazy mode - ninja level - elaborate
 	m := make(map[string]interface{})
 	m["request"] = string(reqdump)
-	for i := 0; i < len(p.options.RequestMatchReplaceDSL); i++ {
-		v, err := dsl.EvalExpr(string(p.options.RequestMatchReplaceDSL[i]), m)
+	for _, expr := range p.options.RequestMatchReplaceDSL {
+		v, err := dsl.EvalExpr(expr, m)
 		if err != nil {
 			return err
 		}
@@ -201,8 +201,8 @@ func (p *Proxy) MatchReplaceResponse(resp *http.Response) error {
 	// lazy mode - ninja level - elaborate
 	m := make(map[string]interface{})
 	m["response"] = string(respdump)
-	for i := 0; i < len(p.options.ResponseMatchReplaceDSL); i++ {
-		v, err := dsl.EvalExpr(string(p.options.ResponseMatchReplaceDSL[i]), m)
+	for _, expr := range p.options.ResponseMatchReplaceDSL {
+		v, err := dsl.EvalExpr(expr, m)
 
 		if err != nil {
 			return err

--- a/socket.go
+++ b/socket.go
@@ -222,10 +222,10 @@ func (p *SocketConn) pipe(src, dst io.ReadWriter) {
 		// Client => Proxy => Destination
 		if islocal {
 			// DSL
-			for i := 0; i < len(p.RequestMatchReplaceDSL); i++ {
+			for _, expr := range p.RequestMatchReplaceDSL {
 				args := make(map[string]interface{})
 				args["data"] = b
-				newB, err := dsl.EvalExpr(p.RequestMatchReplaceDSL[i], args)
+				newB, err := dsl.EvalExpr(expr, args)
 				// In case of error use the original value
 				if err != nil {
 					log.Printf("%s\n", err)
@@ -241,10 +241,10 @@ func (p *SocketConn) pipe(src, dst io.ReadWriter) {
 			}
 		} else { // Destination => Proxy => Client
 			// DSL
-			for i := 0; i < len(p.ResponseMatchReplaceDSL); i++ {
+			for _, expr := range p.ResponseMatchReplaceDSL {
 				args := make(map[string]interface{})
 				args["data"] = b
-				newB, err := dsl.EvalExpr(p.ResponseMatchReplaceDSL[i], args)
+				newB, err := dsl.EvalExpr(expr, args)
 				// In case of error use the original value
 				if err != nil {
 					log.Printf("%s\n", err)

--- a/socket.go
+++ b/socket.go
@@ -33,8 +33,8 @@ type SocketConn struct {
 	Verbosity               types.Verbosity
 	OutputHex               bool
 	Timeout                 time.Duration
-	RequestMatchReplaceDSL  string
-	ResponseMatchReplaceDSL string
+	RequestMatchReplaceDSL  []string
+	ResponseMatchReplaceDSL []string
 	OnRequest               func([]byte) []byte
 	OnResponse              func([]byte) []byte
 }
@@ -54,8 +54,8 @@ type SocketProxyOptions struct {
 	Verbosity               types.Verbosity
 	OutputHex               bool
 	Timeout                 time.Duration
-	RequestMatchReplaceDSL  string
-	ResponseMatchReplaceDSL string
+	RequestMatchReplaceDSL  []string
+	ResponseMatchReplaceDSL []string
 	OnRequest               func([]byte) []byte
 	OnResponse              func([]byte) []byte
 }
@@ -222,10 +222,10 @@ func (p *SocketConn) pipe(src, dst io.ReadWriter) {
 		// Client => Proxy => Destination
 		if islocal {
 			// DSL
-			if p.RequestMatchReplaceDSL != "" {
+			for i := 0; i < len(p.RequestMatchReplaceDSL); i++ {
 				args := make(map[string]interface{})
 				args["data"] = b
-				newB, err := dsl.EvalExpr(p.RequestMatchReplaceDSL, args)
+				newB, err := dsl.EvalExpr(p.RequestMatchReplaceDSL[i], args)
 				// In case of error use the original value
 				if err != nil {
 					log.Printf("%s\n", err)
@@ -241,10 +241,10 @@ func (p *SocketConn) pipe(src, dst io.ReadWriter) {
 			}
 		} else { // Destination => Proxy => Client
 			// DSL
-			if p.ResponseMatchReplaceDSL != "" {
+			for i := 0; i < len(p.ResponseMatchReplaceDSL); i++ {
 				args := make(map[string]interface{})
 				args["data"] = b
-				newB, err := dsl.EvalExpr(p.ResponseMatchReplaceDSL, args)
+				newB, err := dsl.EvalExpr(p.ResponseMatchReplaceDSL[i], args)
 				// In case of error use the original value
 				if err != nil {
 					log.Printf("%s\n", err)


### PR DESCRIPTION
## Proposed changes

<!--
Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request.
-->


As initially discussed in https://github.com/projectdiscovery/proxify/discussions/196, it'd be nice to support multiple DSL matches on requests and responses. For consistency, I added the same behavior to the match-replace DSLs.

The updated code loops over the defined matches and will perform each of them. The match-replace items allow the replaces to be chained, so text in the first match-replace could be replaced by text in a subsequent match-replace. An example would look like:

```yaml
response-match-replace-dsl:
  - "replace(response,'example.com','test.com')"
  - "replace(response,'test','google')"

```
In the event that `example.com` was replaced in a response, the resultant text would be `google.com`. Users would need to be aware of overlapping replacements.

The `MatchReplaceRequest` and `MatchReplaceResponse` functions were not the simplest to switch over, so there may be a better solution.

The mitmrelay tool doesn't currenntly use goflags. To keep the scope of the PR small, I decided to insert the single match-replace DSLs into a string slice.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)