### PR TITLE
adding passthrough support + path fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ OUTPUT:
    -dump-resp          Dump only HTTP responses to output file
 
 FILTER:
-   -req-fd, -request-dsl string                   Request Filter DSL
-   -resp-fd, -response-dsl string                 Response Filter DSL
-   -req-mrd, -request-match-replace-dsl string    Request Match-Replace DSL
-   -resp-mrd, -response-match-replace-dsl string  Response Match-Replace DSL
+   -req-fd, -request-dsl string[]                   Request Filter DSL
+   -resp-fd, -response-dsl string[]                 Response Filter DSL
+   -req-mrd, -request-match-replace-dsl string[]    Request Match-Replace DSL
+   -resp-mrd, -response-match-replace-dsl string[]  Response Match-Replace DSL
 
 NETWORK:
    -ha, -http-addr string    Listening HTTP IP and Port address (ip:port) (default "127.0.0.1:8888")
@@ -85,9 +85,9 @@ NETWORK:
    -r, -resolver string      Custom DNS resolvers to use (ip:port)
 
 PROXY:
-   -hp, -http-proxy string    Upstream HTTP Proxies (eg http://proxy-ip:proxy-port
-   -sp, -socks5-proxy string  Upstream SOCKS5 Proxies (eg socks5://proxy-ip:proxy-port)
-   -c int                     Number of requests before switching to the next upstream proxy (default 1)
+   -hp, -http-proxy string[]    Upstream HTTP Proxies (eg http://proxy-ip:proxy-port)
+   -sp, -socks5-proxy string[]  Upstream SOCKS5 Proxies (eg socks5://proxy-ip:proxy-port)
+   -c int                       Number of requests before switching to the next upstream proxy (default 1)
 
 EXPORT:
    -elastic-address string    elasticsearch address (ip:port)
@@ -100,17 +100,18 @@ EXPORT:
    -kafka-topic string        kafka topic to publish messages on (default "proxify")
 
 CONFIGURATION:
-   -config string        Directory for storing program information (default "/Users/geekboy/.config/proxify")
-   -cert-cache-size int  Number of certificates to cache (default 256)
-   -allow string         Allowed list of IP/CIDR's to be proxied
-   -deny string          Denied list of IP/CIDR's to be proxied
+   -config string              Directory for storing program information (default "$HOME/.config/proxify")
+   -cert-cache-size int        Number of certificates to cache (default 256)
+   -a, -allow string[]         Allowed list of IP/CIDR's to be proxied
+   -d, -deny string[]          Denied list of IP/CIDR's to be proxied
+   -pt, -passthrough string[]  List of passthrough domains
 
 DEBUG:
-   -nc, -no-color       No Color (default true)
-   -version             Version
-   -silent              Silent
-   -v, -verbose         Verbose
-   -vv, -very-verbose   Very Verbose
+   -nc, -no-color      No Color (default true)
+   -version            Version
+   -silent             Silent
+   -v, -verbose        Verbose
+   -vv, -very-verbose  Very Verbose
 ```
 
 ### Running Proxify
@@ -125,7 +126,17 @@ Runs an HTTP proxy on custom port **1111**:
 proxify -http-addr ":1111"
 ```
 
+### TLS pass through
+
+The -pt flag can be used pass through (skip) encrypted traffic without attempting to terminate the TLS connection.
+
+
+```bash
+proxify -pt '(.*\.)?google\.co.in.*'
+```
+
 ### Proxify with upstream proxy
+
 
 Runs an HTTP proxy on port 8888 and forward the traffic to burp on port **8080**:
 ```shell

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -2,7 +2,7 @@ package runner
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
@@ -39,6 +39,7 @@ type Options struct {
 	Allow                       goflags.StringSlice // Allow ip/cidr
 	Elastic                     elastic.Options
 	Kafka                       kafka.Options
+	PassThrough                 goflags.StringSlice // Passthrough items list
 }
 
 func ParseOptions() *Options {
@@ -94,10 +95,11 @@ func ParseOptions() *Options {
 
 	createGroup(flagSet, "configuration", "Configuration",
 		// Todo: default config file support (homeDir/.config/proxify/config.yaml)
-		flagSet.StringVar(&options.Directory, "config", path.Join(homeDir, ".config", "proxify"), "Directory for storing program information"),
+		flagSet.StringVar(&options.Directory, "config", filepath.Join(homeDir, ".config", "proxify"), "Directory for storing program information"),
 		flagSet.IntVar(&options.CertCacheSize, "cert-cache-size", 256, "Number of certificates to cache"),
 		flagSet.StringSliceVarP(&options.Allow, "allow", "a", nil, "Allowed list of IP/CIDR's to be proxied", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.Deny, "deny", "d", nil, "Denied list of IP/CIDR's to be proxied", goflags.FileNormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.PassThrough, "passthrough", "pt", nil, "List of passthrough domains", goflags.NormalizedStringSliceOptions),
 	)
 
 	silent, verbose, veryVerbose := false, false, false

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -40,6 +40,7 @@ func NewRunner(options *Options) (*Runner, error) {
 		Kafka:                       &options.Kafka,
 		Allow:                       options.Allow,
 		Deny:                        options.Deny,
+		PassThrough:                 options.PassThrough,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -9,13 +9,13 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/pem"
-	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/elazarl/goproxy"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
+	fileutil "github.com/projectdiscovery/utils/file"
 )
 
 // Manager implements a certificate signing authority for TLS Mitm.
@@ -39,12 +39,10 @@ const (
 func New(options *Options) (*Manager, error) {
 	manager := &Manager{}
 
-	certFile := path.Join(options.Directory, caCertName)
-	keyFile := path.Join(options.Directory, caKeyName)
+	certFile := filepath.Join(options.Directory, caCertName)
+	keyFile := filepath.Join(options.Directory, caKeyName)
 
-	_, certFileErr := os.Stat(certFile)
-	_, keyFileErr := os.Stat(keyFile)
-	if os.IsNotExist(certFileErr) || os.IsNotExist(keyFileErr) {
+	if !fileutil.FileExists(certFile) || !fileutil.FileExists(keyFile) {
 		if err := manager.createAuthority(certFile, keyFile); err != nil {
 			return nil, errors.Wrap(err, "could not create certificate authority")
 		}

--- a/pkg/logger/file/file.go
+++ b/pkg/logger/file/file.go
@@ -3,9 +3,10 @@ package file
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/projectdiscovery/proxify/pkg/types"
+	fileutil "github.com/projectdiscovery/utils/file"
 )
 
 // Options required for file export
@@ -21,17 +22,14 @@ type Client struct {
 
 // New creates and returns a new client for file based logging
 func New(option *Options) (*Client, error) {
-	return &Client{
-		options: &Options{
-			OutputFolder: option.OutputFolder,
-		},
-	}, CreateOutputFolder(option.OutputFolder)
+	client := &Client{options: &Options{OutputFolder: option.OutputFolder}}
+	return client, fileutil.CreateFolder(option.OutputFolder)
 }
 
 // Store writes the log to the file
 func (c *Client) Save(data types.OutputData) error {
 	// generate the file destination file name
-	destFile := path.Join(c.options.OutputFolder, fmt.Sprintf("%s.%s", data.Name, "txt"))
+	destFile := filepath.Join(c.options.OutputFolder, fmt.Sprintf("%s.%s", data.Name, "txt"))
 	// if it's a response and file doesn't exist skip
 	f, err := os.OpenFile(destFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -40,9 +38,4 @@ func (c *Client) Save(data types.OutputData) error {
 	// write to file
 	fmt.Fprint(f, data.DataString)
 	return f.Close()
-}
-
-// CreateOutputFolder creates the output folder if it doesn't exist
-func CreateOutputFolder(outputFolder string) error {
-	return os.MkdirAll(outputFolder, 0755)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 	"strings"
 )
 
@@ -70,4 +71,14 @@ func HTTPResponseToMap(resp *http.Response) (map[string]interface{}, error) {
 	}
 
 	return m, nil
+}
+
+// MatchAnyRegex checks if data matches any pattern
+func MatchAnyRegex(regexes []string, data string) bool {
+	for _, regex := range regexes {
+		if ok, err := regexp.MatchString(regex, data); err == nil && ok {
+			return true
+		}
+	}
+	return false
 }

--- a/proxy.go
+++ b/proxy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectdiscovery/proxify/pkg/types"
 	"github.com/projectdiscovery/proxify/pkg/util"
 	"github.com/projectdiscovery/tinydns"
+	sliceutil "github.com/projectdiscovery/utils/slice"
 	"github.com/rs/xid"
 	"golang.org/x/net/proxy"
 )
@@ -63,6 +64,7 @@ type Options struct {
 	OnResponseCallback          OnResponseFunc
 	Deny                        []string
 	Allow                       []string
+	PassThrough                 []string
 	UpstreamProxyRequestsNumber int
 	Elastic                     *elastic.Options
 	Kafka                       *kafka.Options
@@ -141,11 +143,17 @@ func (p *Proxy) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Res
 }
 
 func (p *Proxy) OnConnectHTTP(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+	if sliceutil.Contains(p.options.PassThrough, host) {
+		return goproxy.OkConnect, host
+	}
 	ctx.UserData = types.UserData{Host: host}
 	return goproxy.HTTPMitmConnect, host
 }
 
 func (p *Proxy) OnConnectHTTPS(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+	if sliceutil.Contains(p.options.PassThrough, host) {
+		return goproxy.OkConnect, host
+	}
 	ctx.UserData = types.UserData{Host: host}
 	return goproxy.MitmConnect, host
 }

--- a/proxy.go
+++ b/proxy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/projectdiscovery/proxify/pkg/types"
 	"github.com/projectdiscovery/proxify/pkg/util"
 	"github.com/projectdiscovery/tinydns"
-	sliceutil "github.com/projectdiscovery/utils/slice"
 	"github.com/rs/xid"
 	"golang.org/x/net/proxy"
 )
@@ -143,7 +142,7 @@ func (p *Proxy) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Res
 }
 
 func (p *Proxy) OnConnectHTTP(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-	if sliceutil.Contains(p.options.PassThrough, host) {
+	if util.MatchAnyRegex(p.options.PassThrough, host) {
 		return goproxy.OkConnect, host
 	}
 	ctx.UserData = types.UserData{Host: host}
@@ -151,7 +150,7 @@ func (p *Proxy) OnConnectHTTP(host string, ctx *goproxy.ProxyCtx) (*goproxy.Conn
 }
 
 func (p *Proxy) OnConnectHTTPS(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-	if sliceutil.Contains(p.options.PassThrough, host) {
+	if util.MatchAnyRegex(p.options.PassThrough, host) {
 		return goproxy.OkConnect, host
 	}
 	ctx.UserData = types.UserData{Host: host}


### PR DESCRIPTION
## Proposed changes
Adding experimental passthrough support via new `-pt host:port` CLI parameter:
```console
$ proxify -pt 192.168.1.1:443
[INF] HTTP Proxy Listening on 127.0.0.1:8888
[INF] Socks5 Proxy Listening on 127.0.0.1:10080
[INF] Saving proxify traffic to logs
...
$ curl https://192.168.1.1 --proxy http://127.0.0.1:8888 -k
$ ls -la logs/ # no request was intercepted
$
```

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)