### PR TITLE
fix passthrough option

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -118,7 +118,7 @@ func ParseOptions() (*Options, error) {
 		flagSet.IntVar(&options.CertCacheSize, "cert-cache-size", 256, "Number of certificates to cache"),
 		flagSet.StringSliceVarP(&options.Allow, "allow", "a", nil, "Allowed list of IP/CIDR's to be proxied", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.Deny, "deny", "d", nil, "Denied list of IP/CIDR's to be proxied", goflags.FileNormalizedStringSliceOptions),
-		flagSet.StringSliceVarP(&options.PassThrough, "passthrough", "pt", nil, "List of passthrough domains", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.PassThrough, "passthrough", "pt", nil, "List of passthrough domains", goflags.FileNormalizedStringSliceOptions),
 	)
 
 	silent, verbose, veryVerbose := false, false, false

--- a/proxy.go
+++ b/proxy.go
@@ -258,11 +258,8 @@ func (p *Proxy) Run() error {
 	// http proxy
 	if p.httpProxy != nil {
 		p.httpProxy.TLSPassthroughFunc = func(req *http.Request) bool {
-			// if !stringsutil.ContainsAny(req.URL.Host, "avatars") {
-			// 	log.Printf("Skipped MITM for %v", req.URL.Host)
-			// 	return true
-			// }
-			return false
+			// Skip MITM for hosts that are in pass-through list
+			return util.MatchAnyRegex(p.options.PassThrough, req.Host)
 		}
 
 		p.httpProxy.SetRequestModifier(p)

--- a/proxy.go
+++ b/proxy.go
@@ -272,31 +272,6 @@ func (p *Proxy) Run() error {
 			}
 			gologger.Fatal().Msgf("%v", p.httpProxy.Serve(l))
 		}()
-
-		// // Serve the certificate when the user makes requests to /proxify
-		// p.httpproxy.OnRequest(goproxy.DstHostIs("proxify")).DoFunc(
-		// 	func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		// 		if r.URL.Path != "/cacert.crt" {
-		// 			return r, goproxy.NewResponse(r, "text/plain", 404, "Invalid path given")
-		// 		}
-
-		// 		_, ca := p.certs.GetCA()
-		// 		reader := bytes.NewReader(ca)
-
-		// 		header := http.Header{}
-		// 		header.Set("Content-Type", "application/pkix-cert")
-		// 		resp := &http.Response{
-		// 			Request:          r,
-		// 			TransferEncoding: r.TransferEncoding,
-		// 			Header:           header,
-		// 			StatusCode:       200,
-		// 			Status:           http.StatusText(200),
-		// 			ContentLength:    int64(reader.Len()),
-		// 			Body:             io.NopCloser(reader),
-		// 		}
-		// 		return r, resp
-		// 	},
-		// )
 	}
 
 	// socks5 proxy


### PR DESCRIPTION
- closes #350 

## Test
```console
✗ go run . -pt ".*"            


                       _ ___    
   ___  _______ __ __ (_) _/_ __
  / _ \/ __/ _ \\ \ // / _/ // /
 / .__/_/  \___/_\_\/_/_/ \_, / 
/_/                      /___/

                projectdiscovery.io

[INF] Current proxify version v0.0.12 (latest)
[INF] HTTP Proxy Listening on 127.0.0.1:8888
[INF] Socks5 Proxy Listening on 127.0.0.1:10080
[INF] Saving proxify traffic to logs
```
- curl
```console
✗ curl -s -x http://127.0.0.1:8888 -vI https://www.google.com/ 2>&1
....
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.google.com
*  start date: Aug 14 08:23:03 2023 GMT
*  expire date: Nov  6 08:23:02 2023 GMT
*  subjectAltName: host "www.google.com" matched cert's "www.google.com"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1C3
*  SSL certificate verify ok.
....
```