### PR TITLE
Default to jsonl output on export options

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -172,6 +172,11 @@ func ParseOptions() (*Options, error) {
 		}
 	}
 
+	// On export mode default to jsonl output
+	if options.Elastic.Addr != "" || options.Kafka.Addr != "" {
+		options.OutputJsonl = true
+	}
+	
 	return options, nil
 }
 


### PR DESCRIPTION
### closes
- #220 
- #213 

## Test
1. Elasticsearch setup
```console
✗ docker run -d --name elasticsearch \
  -p 9200:9200 -p 9300:9300 \
  -e "discovery.type=single-node" \
  -e "ES_JAVA_OPTS=-Xmx256m -Xms256m" \
  docker.elastic.co/elasticsearch/elasticsearch:7.14.0

## Connect elasticsearch with kibana(http://localhost:5601/)
✗ docker run -d --name kibana \
  --link elasticsearch:elasticsearch \
  -p 5601:5601 \
  docker.elastic.co/kibana/kibana:7.14.0
```
2. Run proxify
```console
✗ go run . -elastic-address 127.0.0.1:9200 -v

                       _ ___    
   ___  _______ __ __ (_) _/_ __
  / _ \/ __/ _ \\ \ // / _/ // /
 / .__/_/  \___/_\_\/_/_/ \_, / 
/_/                      /___/

                projectdiscovery.io

[INF] Current proxify version v0.0.12 (latest)
[INF] HTTP Proxy Listening on 127.0.0.1:8888
[INF] Socks5 Proxy Listening on 127.0.0.1:10080
[INF] Saving proxify traffic to logs/proxify.jsonl
[INF] Sending traffic to Elasticsearch at 127.0.0.1:9200
```
3. `curl --proxy http://127.0.0.1:8888 http://example.com`
4. Always the JSON response(includes uri, method, scheme...) at index(http://localhost:9200/proxify/_search)