### PR TITLE
support TLSV1.0

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -353,6 +353,7 @@ func (p *Proxy) getRoundTripper() (http.RoundTripper, error) {
 		MaxIdleConns:        0,
 		MaxConnsPerHost:     0,
 		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS10,
 			InsecureSkipVerify: true,
 		},
 	}


### PR DESCRIPTION
- closes #303 

### Test
```console
✗ go run .                                

                       _ ___    
   ___  _______ __ __ (_) _/_ __
  / _ \/ __/ _ \\ \ // / _/ // /
 / .__/_/  \___/_\_\/_/_/ \_, / 
/_/                      /___/

                projectdiscovery.io

[INF] Current proxify version v0.0.12 (latest)
[INF] HTTP Proxy Listening on 127.0.0.1:8888
[INF] Socks5 Proxy Listening on 127.0.0.1:10080
[INF] Saving proxify traffic to logs

$ httpx -proxy http://127.0.0.1:8888 -u https://tls-v1-0.badssl.com:1010/
```