### PR TITLE
Fix link to /cacert in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ replay -output "logs/"
 
 ### Installing SSL Certificate
 
-A certificate authority is generated for proxify which is stored in the folder `~/.config/proxify/` as default, manually can be specified by `-config` flag. The generated certificate can be imported by visiting [http://proxify/cacert.crt](http://proxify/cacert.crt) in a browser connected to proxify. 
+A certificate authority is generated for proxify which is stored in the folder `~/.config/proxify/` as default, manually can be specified by `-config` flag. The generated certificate can be imported by visiting [http://proxify/cacert](http://proxify/cacert) in a browser connected to proxify. 
 
 Installation steps for the Root Certificate is similar to other proxy tools which includes adding the cert to system trusted root store.
 


### PR DESCRIPTION
## Proposed changes

Fix link in README. Should point to /cacert not /cacert.pem