### PR TITLE
Fail fast when both HTTP and SOCKS5 proxies are set

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -140,6 +141,10 @@ func ParseOptions() (*Options, error) {
 	if options.ConfigDir != "" {
 		_ = os.MkdirAll(options.ConfigDir, permissionutil.ConfigFolderPermission)
 		readFlagsConfig(flagSet, options.ConfigDir)
+	}
+
+	if len(options.UpstreamHTTPProxies) > 0 && len(options.UpstreamSOCKS5Proxies) > 0 {
+		return nil, errors.New("can't use upstream HTTP proxies and upstream SOCKS5 proxies at the same time")
 	}
 
 	if cfgFile != "" {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -112,7 +112,8 @@ func (r *Runner) Run() error {
 
 	if len(r.options.UpstreamHTTPProxies) > 0 {
 		gologger.Info().Msgf("Using upstream HTTP proxies: %s\n", r.options.UpstreamHTTPProxies)
-	} else if len(r.options.UpstreamSOCKS5Proxies) > 0 {
+	}
+	if len(r.options.UpstreamSOCKS5Proxies) > 0 {
 		gologger.Info().Msgf("Using upstream SOCKS5 proxies: %s\n", r.options.UpstreamSOCKS5Proxies)
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -523,7 +523,8 @@ func (p *Proxy) getRoundTripper() (http.RoundTripper, error) {
 		roundtrip = &http.Transport{Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(p.rbHTTP.Next())
 		}, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	} else if len(p.options.UpstreamSOCKS5Proxies) > 0 {
+	}
+	if len(p.options.UpstreamSOCKS5Proxies) > 0 {
 		// for each socks5 proxy create a dialer
 		socks5Dialers := make(map[string]proxy.Dialer)
 		for _, socks5Proxy := range p.options.UpstreamSOCKS5Proxies {


### PR DESCRIPTION
The current implementation only supports either HTTP or SOCKS5 proxy, but this is not shown to the user clearly. If a user tries to set both HTTP and SOCKS5 proxies, fail fast with a clear msg.

closes https://github.com/projectdiscovery/proxify/issues/745

## Proposed changes

<!--
Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request.
-->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/proxify/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)