### PR TITLE
ci: add production release automation workflows

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,29 +1,73 @@
 name: 🔨 Release Test
 
+# PR-only release automation POC.
+# Validates the full goreleaser pipeline (build, archive, checksum) on every
+# qualifying PR without pushing tags or publishing artifacts.
+# Uses reusable building blocks from projectdiscovery/actions.
+
 on:
   pull_request:
     paths:
       - '**.go'
       - '**.mod'
+      - '.goreleaser.yml'
+      - '.github/workflows/release-test.yml'
   workflow_dispatch:
 
 jobs:
   release-test:
+    name: Release dry-run (snapshot)
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read      # read repo + tags; no write so no accidental tag push
+      pull-requests: write # post step summary as PR check annotation
     steps:
-      - name: "Check out code"
+      - name: Check out code
         uses: actions/checkout@v5
-        with: 
-          fetch-depth: 0
+        with:
+          fetch-depth: 0   # full history so svu can walk commits
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      
-      - name: release test
-        uses: goreleaser/goreleaser-action@v6
+
+      # Compute the next semantic version from conventional commits.
+      # svu is read-only here: it only prints the next version string.
+      # No tag is created or pushed — that is left to the real release workflow.
+      - name: Compute next version (dry-run)
+        id: next-version
+        run: |
+          go install github.com/caarlos0/svu/v3@v3.2.3
+          NEXT=$(svu next --tag.mode=all 2>/dev/null || svu current)
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "### 🔖 Next release version (preview): \`${NEXT}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      # Run the full goreleaser release pipeline in snapshot mode via the
+      # reusable projectdiscovery/actions/goreleaser action.
+      # release: 'true'  → uses 'release --skip=validate --clean'
+      # args: '--snapshot' → appended, so nothing is published or tagged.
+      - name: Goreleaser snapshot release
+        uses: projectdiscovery/actions/goreleaser@v1.29.4
         with:
-          args: "release --clean --snapshot"
-          version: latest
-          workdir: .
+          release: 'true'
+          args: '--snapshot'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # Tell goreleaser which version this snapshot represents so the
+          # artifact names match what the real release would produce.
+          GORELEASER_CURRENT_TAG: "${{ steps.next-version.outputs.version }}"
+
+      - name: Summarise artifacts
+        if: success()
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### Snapshot artifacts built for \`${{ steps.next-version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -d dist ]; then
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            ls dist/*.zip dist/*.tar.gz dist/checksums.txt 2>/dev/null | xargs -I{} basename {} >> "$GITHUB_STEP_SUMMARY" || ls dist/ >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> ✅ No tags were pushed. No artifacts were published. This is a dry-run only." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

This PR replaces the earlier PR-only POC with the **actual release automation flow** for proxify, built on the reusable pieces already merged in [`projectdiscovery/actions`](https://github.com/projectdiscovery/actions).

## Files changed

1. **`.github/workflows/release-tag.yml`** — new workflow
   - Runs automatically on pushes to `main`
   - Uses `projectdiscovery/actions/svu-next@v1.29.4` to compute and create the next release tag
   - Supports manual `workflow_dispatch` controls for:
     - `ref`
     - `dry-run`
     - `always-bump`
     - `prerelease`
     - `metadata`
     - `tag-prefix`
     - `v0`

2. **`.github/workflows/release-binary.yml`** — production publish workflow
   - Still publishes on `push.tags: v*`
   - Switched from direct `goreleaser/goreleaser-action` usage to `projectdiscovery/actions/goreleaser@v1.29.4`
   - Adds guarded manual `workflow_dispatch` support with:
     - required `tag`
     - optional `ref`
     - `announce` toggle
     - extra `goreleaser-args`
   - Rejects manual runs that do not target an explicit `v*` tag
   - Sets `GORELEASER_CURRENT_TAG` explicitly for manual publish runs

## Resulting release flow

### Automatic path

1. Merge to `main`
2. `release-tag.yml` computes the next version and pushes the tag
3. Tag push triggers `release-binary.yml`
4. `release-binary.yml` publishes the GitHub release and binaries via GoReleaser

### Manual path

- Run **Create Release Tag** to preview or create the next tag from any ref
- Run **Release Binary** against an explicit existing tag when you need a controlled manual publish or re-run

## Guardrails kept in the real workflow

- PRs do **not** publish anything
- Manual publish requires an explicit `v*` tag
- Announcements can be disabled for manual runs
- Tag creation and binary publishing stay separated into two workflows, so tag creation remains the release gate

## Why this uses `projectdiscovery/actions`

The release safety and shared behavior now live centrally in the actions repo:
- `svu-next` handles next-version calculation and optional dry-run tagging
- `goreleaser` wraps the shared GoReleaser invocation

That keeps proxify as a thin consumer and makes rollout to other repos straightforward.