### PR TITLE
ci: add release-preview job to PR workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,9 @@ jobs:
         run: go build -race .
         working-directory: cmd/proxify/
 
-      
+  release-preview:
+    name: Release preview
+    uses: projectdiscovery/actions/.github/workflows/release-preview.yaml@master
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
-      


### PR DESCRIPTION
## What

Adds a `release-preview` job to the existing `build-test.yml` PR workflow, powered by the new [`projectdiscovery/actions/release-preview`](https://github.com/projectdiscovery/actions/blob/master/.github/workflows/release-preview.yaml) reusable workflow (merged in actions#104).

## What it does on every PR

1. Checks out the full git history
2. Runs `svu next` to compute the next semver version from conventional commits
3. Writes a job summary: `Next version: **v1.2.3**`

## What it does NOT do

- ❌ Creates any git tag
- ❌ Creates any GitHub release
- ❌ Publishes any artifact

Completely safe for PR triggers.

## How to verify

Open any PR that touches `.go` or `.mod` files — the `Release preview` check will appear alongside the build matrix and its summary will show the predicted next version.