### PR TITLE
ci: add production release automation workflows

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -5,29 +5,103 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish, for example v0.0.16
+        required: true
+        type: string
+      ref:
+        description: Optional git ref to check out; defaults to the selected tag
+        required: false
+        default: ''
+        type: string
+      announce:
+        description: Send Slack and Discord release announcements
+        required: false
+        default: true
+        type: boolean
+      goreleaser-args:
+        description: Extra arguments forwarded to goreleaser release
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest-16-cores
     steps:
-      - name: "Check out code"
+      - name: Check out code
         uses: actions/checkout@v5
-        with: 
+        with:
           fetch-depth: 0
-      
-      - name: "Set up Go"
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || inputs.tag) || github.ref }}
+
+      - name: Set up Go
         uses: actions/setup-go@v5
-        with: 
+        with:
           go-version: 1.21.x
 
-      - name: "Create release on GitHub"
-        uses: goreleaser/goreleaser-action@v6
-        with: 
-          args: "release --clean"
-          version: latest
-          workdir: .
+      - name: Resolve release settings
+        id: release
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          SLACK_WEBHOOK: "${{ secrets.RELEASE_SLACK_WEBHOOK }}"
-          DISCORD_WEBHOOK_ID: "${{ secrets.DISCORD_WEBHOOK_ID }}"
-          DISCORD_WEBHOOK_TOKEN: "${{ secrets.DISCORD_WEBHOOK_TOKEN }}"
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_ANNOUNCE: ${{ github.event_name == 'workflow_dispatch' && inputs.announce && 'true' || 'false' }}
+          INPUT_EXTRA_ARGS: ${{ github.event_name == 'workflow_dispatch' && inputs.goreleaser-args || '' }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+            ANNOUNCE="$INPUT_ANNOUNCE"
+          else
+            TAG="$GITHUB_REF_NAME"
+            ANNOUNCE="true"
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "::error::A release tag is required for manual release runs."
+            exit 1
+          fi
+
+          case "$TAG" in
+            v*) ;;
+            *)
+              echo "::error::Release tag must start with 'v' (got: $TAG)."
+              exit 1
+              ;;
+          esac
+
+          EXTRA_ARGS="$INPUT_EXTRA_ARGS"
+          if [ "$ANNOUNCE" != "true" ]; then
+            EXTRA_ARGS="--skip=announce $EXTRA_ARGS"
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "announce=$ANNOUNCE" >> "$GITHUB_OUTPUT"
+          echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### 🎉 Release publish"
+            echo ""
+            echo "- Tag: \`$TAG\`"
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "- Trigger: manual"
+            else
+              echo "- Trigger: tag push"
+            fi
+            echo "- Announcements: \`$ANNOUNCE\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release on GitHub
+        uses: projectdiscovery/actions/goreleaser@v1.29.4
+        with:
+          release: 'true'
+          args: ${{ steps.release.outputs.args }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.release.outputs.tag }}
+          SLACK_WEBHOOK: ${{ steps.release.outputs.announce == 'true' && secrets.RELEASE_SLACK_WEBHOOK || '' }}
+          DISCORD_WEBHOOK_ID: ${{ steps.release.outputs.announce == 'true' && secrets.DISCORD_WEBHOOK_ID || '' }}
+          DISCORD_WEBHOOK_TOKEN: ${{ steps.release.outputs.announce == 'true' && secrets.DISCORD_WEBHOOK_TOKEN || '' }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,6 +1,10 @@
 name: 🔖 Create Release Tag
 
 on:
+  schedule:
+    # Runs every Monday at 09:00 UTC — creates a tag only if there are
+    # new commits since the last release tag.
+    - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       ref:
@@ -11,22 +15,22 @@ on:
       run-mode:
         description: auto creates and pushes the tag; dry-run only previews it
         required: true
-        default: auto
+        default: dry-run
         type: choice
         options:
           - auto
           - dry-run
       version-bump:
-        description: Strategy for manual runs
+        description: Strategy for the next version
         required: true
-        default: patch
+        default: auto
         type: choice
         options:
           - auto
           - patch
           - custom
       custom-version:
-        description: Custom version for manual runs when version-bump=custom (for example v2.1.2)
+        description: Custom version when version-bump=custom (for example v2.1.2)
         required: false
         default: ''
         type: string
@@ -43,9 +47,39 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || 'main' }}
 
-      - name: Compute next tag preview
+      - name: Check for new commits since last tag (scheduled only)
+        if: github.event_name == 'schedule'
+        id: check-commits
+        run: |
+          last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$last_tag" ]; then
+            echo "no previous tag found, proceeding with first release"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            commit_count="$(git rev-list "${last_tag}..HEAD" --count)"
+            echo "commits since ${last_tag}: ${commit_count}"
+            if [ "$commit_count" -gt 0 ]; then
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "No new commits since ${last_tag} — skipping release." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+      - name: Create scheduled tag
+        if: github.event_name == 'schedule' && steps.check-commits.outputs.has_changes == 'true'
+        id: scheduled-tag
+        uses: projectdiscovery/actions/svu-next@v1.29.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag-prefix: v
+          v0: 'true'
+          set-failed: 'true'
+
+      - name: Compute next tag preview (manual)
+        if: github.event_name == 'workflow_dispatch'
         id: manual-preview
         uses: projectdiscovery/actions/svu-next@v1.29.4
         with:
@@ -56,6 +90,7 @@ jobs:
           set-failed: 'false'
 
       - name: Resolve manual tag
+        if: github.event_name == 'workflow_dispatch'
         id: manual-resolve
         env:
           VERSION_BUMP: ${{ inputs.version-bump }}
@@ -107,7 +142,7 @@ jobs:
           echo "target_tag=$target_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create manual tag
-        if: inputs.run-mode == 'auto'
+        if: github.event_name == 'workflow_dispatch' && inputs.run-mode == 'auto'
         env:
           TARGET_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
         run: |
@@ -124,6 +159,10 @@ jobs:
 
       - name: Summarize tag result
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULED_TAG: ${{ steps.scheduled-tag.outputs.tag }}
+          SCHEDULED_NEXT: ${{ steps.scheduled-tag.outputs.next-tag }}
+          HAS_CHANGES: ${{ steps.check-commits.outputs.has_changes }}
           MANUAL_MODE: ${{ inputs.run-mode }}
           MANUAL_BUMP: ${{ inputs.version-bump }}
           MANUAL_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
@@ -132,9 +171,22 @@ jobs:
           {
             echo "### 🔖 Release tag result"
             echo ""
-            echo "- Trigger: manual workflow_dispatch"
-            echo "- Current tag: \`$MANUAL_CURRENT\`"
-            echo "- Resolved tag: \`$MANUAL_TAG\`"
-            echo "- Run mode: \`$MANUAL_MODE\`"
-            echo "- Version bump: \`$MANUAL_BUMP\`"
+            if [ "$EVENT_NAME" = "schedule" ]; then
+              echo "- Trigger: scheduled (weekly)"
+              if [ "$HAS_CHANGES" = "true" ]; then
+                if [ -n "$SCHEDULED_TAG" ]; then
+                  echo "- Created tag: \`$SCHEDULED_TAG\`"
+                elif [ -n "$SCHEDULED_NEXT" ]; then
+                  echo "- Computed next tag: \`$SCHEDULED_NEXT\`"
+                fi
+              else
+                echo "- No new commits since last tag — skipped."
+              fi
+            else
+              echo "- Trigger: manual"
+              echo "- Current tag: \`$MANUAL_CURRENT\`"
+              echo "- Resolved tag: \`$MANUAL_TAG\`"
+              echo "- Run mode: \`$MANUAL_MODE\`"
+              echo "- Version bump: \`$MANUAL_BUMP\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,9 +1,6 @@
 name: 🔖 Create Release Tag
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       ref:
@@ -46,20 +43,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
-
-      - name: Create next tag from main
-        if: github.event_name == 'push'
-        id: auto-tag
-        uses: projectdiscovery/actions/svu-next@v1.29.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag-prefix: v
-          v0: 'true'
-          set-failed: 'false'
+          ref: ${{ inputs.ref }}
 
       - name: Compute next tag preview
-        if: github.event_name == 'workflow_dispatch'
         id: manual-preview
         uses: projectdiscovery/actions/svu-next@v1.29.4
         with:
@@ -70,7 +56,6 @@ jobs:
           set-failed: 'false'
 
       - name: Resolve manual tag
-        if: github.event_name == 'workflow_dispatch'
         id: manual-resolve
         env:
           VERSION_BUMP: ${{ inputs.version-bump }}
@@ -122,7 +107,7 @@ jobs:
           echo "target_tag=$target_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create manual tag
-        if: github.event_name == 'workflow_dispatch' && inputs.run-mode == 'auto'
+        if: inputs.run-mode == 'auto'
         env:
           TARGET_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
         run: |
@@ -139,9 +124,6 @@ jobs:
 
       - name: Summarize tag result
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          AUTO_TAG: ${{ steps.auto-tag.outputs.tag }}
-          AUTO_NEXT_TAG: ${{ steps.auto-tag.outputs.next-tag }}
           MANUAL_MODE: ${{ inputs.run-mode }}
           MANUAL_BUMP: ${{ inputs.version-bump }}
           MANUAL_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
@@ -150,19 +132,9 @@ jobs:
           {
             echo "### 🔖 Release tag result"
             echo ""
-            if [ "$EVENT_NAME" = "push" ]; then
-              if [ -n "$AUTO_TAG" ]; then
-                echo "- Created tag: \`$AUTO_TAG\`"
-              elif [ -n "$AUTO_NEXT_TAG" ]; then
-                echo "- Computed next tag: \`$AUTO_NEXT_TAG\`"
-              else
-                echo "- No new tag was created."
-              fi
-              echo "- Trigger: automatic on push to \`main\`"
-            else
-              echo "- Current tag: \`$MANUAL_CURRENT\`"
-              echo "- Resolved tag: \`$MANUAL_TAG\`"
-              echo "- Run mode: \`$MANUAL_MODE\`"
-              echo "- Version bump: \`$MANUAL_BUMP\`"
-            fi
+            echo "- Trigger: manual workflow_dispatch"
+            echo "- Current tag: \`$MANUAL_CURRENT\`"
+            echo "- Resolved tag: \`$MANUAL_TAG\`"
+            echo "- Run mode: \`$MANUAL_MODE\`"
+            echo "- Version bump: \`$MANUAL_BUMP\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,9 +27,9 @@ on:
         options:
           - auto
           - patch
-          - exact
-      exact-version:
-        description: Exact version for manual runs when version-bump=exact (for example v2.1.2)
+          - custom
+      custom-version:
+        description: Custom version for manual runs when version-bump=custom (for example v2.1.2)
         required: false
         default: ''
         type: string
@@ -74,7 +74,7 @@ jobs:
         id: manual-resolve
         env:
           VERSION_BUMP: ${{ inputs.version-bump }}
-          EXACT_VERSION: ${{ inputs.exact-version }}
+          CUSTOM_VERSION: ${{ inputs.custom-version }}
           PREVIEW_TAG: ${{ steps.manual-preview.outputs.next-tag }}
         run: |
           current_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
@@ -99,15 +99,15 @@ jobs:
               fi
               target_tag="v${major}.${minor}.$((patch + 1))"
               ;;
-            exact)
-              if [ -z "$EXACT_VERSION" ]; then
-                echo "::error::exact-version is required when version-bump=exact"
+            custom)
+              if [ -z "$CUSTOM_VERSION" ]; then
+                echo "::error::custom-version is required when version-bump=custom"
                 exit 1
               fi
-              case "$EXACT_VERSION" in
-                v*) target_tag="$EXACT_VERSION" ;;
+              case "$CUSTOM_VERSION" in
+                v*) target_tag="$CUSTOM_VERSION" ;;
                 *)
-                  echo "::error::exact-version must start with 'v' (got: $EXACT_VERSION)"
+                  echo "::error::custom-version must start with 'v' (got: $CUSTOM_VERSION)"
                   exit 1
                   ;;
               esac

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,36 +11,28 @@ on:
         required: false
         default: main
         type: string
-      dry-run:
-        description: Compute the next version without creating a tag
-        required: false
-        default: true
-        type: boolean
-      always-bump:
-        description: Increment the patch version when commits do not imply a bump
-        required: false
-        default: false
-        type: boolean
-      prerelease:
-        description: Optional prerelease label, for example rc.1
+      run-mode:
+        description: auto creates and pushes the tag; dry-run only previews it
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - dry-run
+      version-bump:
+        description: Strategy for manual runs
+        required: true
+        default: patch
+        type: choice
+        options:
+          - auto
+          - patch
+          - exact
+      exact-version:
+        description: Exact version for manual runs when version-bump=exact (for example v2.1.2)
         required: false
         default: ''
         type: string
-      metadata:
-        description: Optional build metadata suffix
-        required: false
-        default: ''
-        type: string
-      tag-prefix:
-        description: Tag prefix to generate
-        required: false
-        default: v
-        type: string
-      v0:
-        description: Prevent major version bumps while the project is still v0
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: write
@@ -66,40 +58,111 @@ jobs:
           v0: 'true'
           set-failed: 'false'
 
-      - name: Run manual tag flow
+      - name: Compute next tag preview
         if: github.event_name == 'workflow_dispatch'
-        id: manual-tag
+        id: manual-preview
         uses: projectdiscovery/actions/svu-next@v1.29.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: ${{ inputs.dry-run && 'true' || 'false' }}
-          always: ${{ inputs.always-bump && 'true' || 'false' }}
-          prerelease: ${{ inputs.prerelease }}
-          metadata: ${{ inputs.metadata }}
-          tag-prefix: ${{ inputs.tag-prefix }}
-          v0: ${{ inputs.v0 && 'true' || 'false' }}
+          dry-run: 'true'
+          tag-prefix: v
+          v0: 'true'
           set-failed: 'false'
+
+      - name: Resolve manual tag
+        if: github.event_name == 'workflow_dispatch'
+        id: manual-resolve
+        env:
+          VERSION_BUMP: ${{ inputs.version-bump }}
+          EXACT_VERSION: ${{ inputs.exact-version }}
+          PREVIEW_TAG: ${{ steps.manual-preview.outputs.next-tag }}
+        run: |
+          current_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$current_tag" ]; then
+            current_tag="v0.0.0"
+          fi
+
+          case "$VERSION_BUMP" in
+            auto)
+              target_tag="$PREVIEW_TAG"
+              if [ -z "$target_tag" ]; then
+                target_tag="$current_tag"
+              fi
+              ;;
+            patch)
+              version="${current_tag#v}"
+              version="${version%%-*}"
+              IFS='.' read -r major minor patch <<< "$version"
+              if [ -z "$major" ] || [ -z "$minor" ] || [ -z "$patch" ]; then
+                echo "::error::Unable to parse current tag: $current_tag"
+                exit 1
+              fi
+              target_tag="v${major}.${minor}.$((patch + 1))"
+              ;;
+            exact)
+              if [ -z "$EXACT_VERSION" ]; then
+                echo "::error::exact-version is required when version-bump=exact"
+                exit 1
+              fi
+              case "$EXACT_VERSION" in
+                v*) target_tag="$EXACT_VERSION" ;;
+                *)
+                  echo "::error::exact-version must start with 'v' (got: $EXACT_VERSION)"
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              echo "::error::Unsupported version-bump: $VERSION_BUMP"
+              exit 1
+              ;;
+          esac
+
+          echo "current_tag=$current_tag" >> "$GITHUB_OUTPUT"
+          echo "target_tag=$target_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create manual tag
+        if: github.event_name == 'workflow_dispatch' && inputs.run-mode == 'auto'
+        env:
+          TARGET_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
+        run: |
+          if [ -z "$TARGET_TAG" ]; then
+            echo "::error::No target tag was resolved."
+            exit 1
+          fi
+          if git rev-parse "$TARGET_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag already exists: $TARGET_TAG"
+            exit 1
+          fi
+          git tag "$TARGET_TAG"
+          git push origin "$TARGET_TAG"
 
       - name: Summarize tag result
         env:
           EVENT_NAME: ${{ github.event_name }}
-          CREATED_TAG: ${{ steps.auto-tag.outputs.tag || steps.manual-tag.outputs.tag }}
-          NEXT_TAG: ${{ steps.auto-tag.outputs.next-tag || steps.manual-tag.outputs.next-tag }}
-          MANUAL_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run && 'true' || 'false' }}
+          AUTO_TAG: ${{ steps.auto-tag.outputs.tag }}
+          AUTO_NEXT_TAG: ${{ steps.auto-tag.outputs.next-tag }}
+          MANUAL_MODE: ${{ inputs.run-mode }}
+          MANUAL_BUMP: ${{ inputs.version-bump }}
+          MANUAL_TAG: ${{ steps.manual-resolve.outputs.target_tag }}
+          MANUAL_CURRENT: ${{ steps.manual-resolve.outputs.current_tag }}
         run: |
           {
             echo "### 🔖 Release tag result"
             echo ""
-            if [ -n "$CREATED_TAG" ]; then
-              echo "- Created tag: \`$CREATED_TAG\`"
-            elif [ -n "$NEXT_TAG" ]; then
-              echo "- Computed next tag: \`$NEXT_TAG\`"
-            else
-              echo "- No new tag was created."
-            fi
-            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-              echo "- Manual dry-run: \`$MANUAL_DRY_RUN\`"
-            else
+            if [ "$EVENT_NAME" = "push" ]; then
+              if [ -n "$AUTO_TAG" ]; then
+                echo "- Created tag: \`$AUTO_TAG\`"
+              elif [ -n "$AUTO_NEXT_TAG" ]; then
+                echo "- Computed next tag: \`$AUTO_NEXT_TAG\`"
+              else
+                echo "- No new tag was created."
+              fi
               echo "- Trigger: automatic on push to \`main\`"
+            else
+              echo "- Current tag: \`$MANUAL_CURRENT\`"
+              echo "- Resolved tag: \`$MANUAL_TAG\`"
+              echo "- Run mode: \`$MANUAL_MODE\`"
+              echo "- Version bump: \`$MANUAL_BUMP\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,105 @@
+name: 🔖 Create Release Tag
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to evaluate for the next release tag
+        required: false
+        default: main
+        type: string
+      dry-run:
+        description: Compute the next version without creating a tag
+        required: false
+        default: true
+        type: boolean
+      always-bump:
+        description: Increment the patch version when commits do not imply a bump
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: Optional prerelease label, for example rc.1
+        required: false
+        default: ''
+        type: string
+      metadata:
+        description: Optional build metadata suffix
+        required: false
+        default: ''
+        type: string
+      tag-prefix:
+        description: Tag prefix to generate
+        required: false
+        default: v
+        type: string
+      v0:
+        description: Prevent major version bumps while the project is still v0
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Compute and create release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+
+      - name: Create next tag from main
+        if: github.event_name == 'push'
+        id: auto-tag
+        uses: projectdiscovery/actions/svu-next@v1.29.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag-prefix: v
+          v0: 'true'
+          set-failed: 'false'
+
+      - name: Run manual tag flow
+        if: github.event_name == 'workflow_dispatch'
+        id: manual-tag
+        uses: projectdiscovery/actions/svu-next@v1.29.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: ${{ inputs.dry-run && 'true' || 'false' }}
+          always: ${{ inputs.always-bump && 'true' || 'false' }}
+          prerelease: ${{ inputs.prerelease }}
+          metadata: ${{ inputs.metadata }}
+          tag-prefix: ${{ inputs.tag-prefix }}
+          v0: ${{ inputs.v0 && 'true' || 'false' }}
+          set-failed: 'false'
+
+      - name: Summarize tag result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATED_TAG: ${{ steps.auto-tag.outputs.tag || steps.manual-tag.outputs.tag }}
+          NEXT_TAG: ${{ steps.auto-tag.outputs.next-tag || steps.manual-tag.outputs.next-tag }}
+          MANUAL_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run && 'true' || 'false' }}
+        run: |
+          {
+            echo "### 🔖 Release tag result"
+            echo ""
+            if [ -n "$CREATED_TAG" ]; then
+              echo "- Created tag: \`$CREATED_TAG\`"
+            elif [ -n "$NEXT_TAG" ]; then
+              echo "- Computed next tag: \`$NEXT_TAG\`"
+            else
+              echo "- No new tag was created."
+            fi
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "- Manual dry-run: \`$MANUAL_DRY_RUN\`"
+            else
+              echo "- Trigger: automatic on push to \`main\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,73 +1,29 @@
 name: 🔨 Release Test
 
-# PR-only release automation POC.
-# Validates the full goreleaser pipeline (build, archive, checksum) on every
-# qualifying PR without pushing tags or publishing artifacts.
-# Uses reusable building blocks from projectdiscovery/actions.
-
 on:
   pull_request:
     paths:
       - '**.go'
       - '**.mod'
-      - '.goreleaser.yml'
-      - '.github/workflows/release-test.yml'
   workflow_dispatch:
 
 jobs:
   release-test:
-    name: Release dry-run (snapshot)
     runs-on: ubuntu-latest-16-cores
-    permissions:
-      contents: read      # read repo + tags; no write so no accidental tag push
-      pull-requests: write # post step summary as PR check annotation
     steps:
-      - name: Check out code
+      - name: "Check out code"
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0   # full history so svu can walk commits
+        with: 
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-
-      # Compute the next semantic version from conventional commits.
-      # svu is read-only here: it only prints the next version string.
-      # No tag is created or pushed — that is left to the real release workflow.
-      - name: Compute next version (dry-run)
-        id: next-version
-        run: |
-          go install github.com/caarlos0/svu/v3@v3.2.3
-          NEXT=$(svu next --tag.mode=all 2>/dev/null || svu current)
-          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
-          echo "### 🔖 Next release version (preview): \`${NEXT}\`" >> "$GITHUB_STEP_SUMMARY"
-
-      # Run the full goreleaser release pipeline in snapshot mode via the
-      # reusable projectdiscovery/actions/goreleaser action.
-      # release: 'true'  → uses 'release --skip=validate --clean'
-      # args: '--snapshot' → appended, so nothing is published or tagged.
-      - name: Goreleaser snapshot release
-        uses: projectdiscovery/actions/goreleaser@v1.29.4
+      
+      - name: release test
+        uses: goreleaser/goreleaser-action@v6
         with:
-          release: 'true'
-          args: '--snapshot'
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          # Tell goreleaser which version this snapshot represents so the
-          # artifact names match what the real release would produce.
-          GORELEASER_CURRENT_TAG: "${{ steps.next-version.outputs.version }}"
-
-      - name: Summarise artifacts
-        if: success()
-        run: |
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "#### Snapshot artifacts built for \`${{ steps.next-version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -d dist ]; then
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            ls dist/*.zip dist/*.tar.gz dist/checksums.txt 2>/dev/null | xargs -I{} basename {} >> "$GITHUB_STEP_SUMMARY" || ls dist/ >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "> ✅ No tags were pushed. No artifacts were published. This is a dry-run only." >> "$GITHUB_STEP_SUMMARY"
+          args: "release --clean --snapshot"
+          version: latest
+          workdir: .

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,29 +1,73 @@
 name: 🔨 Release Test
 
+# PR-only release automation POC.
+# Validates the full goreleaser pipeline (build, archive, checksum) on every
+# qualifying PR without pushing tags or publishing artifacts.
+# Uses reusable building blocks from projectdiscovery/actions.
+
 on:
   pull_request:
     paths:
       - '**.go'
       - '**.mod'
+      - '.goreleaser.yml'
+      - '.github/workflows/release-test.yml'
   workflow_dispatch:
 
 jobs:
   release-test:
+    name: Release dry-run (snapshot)
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read      # read repo + tags; no write so no accidental tag push
+      pull-requests: write # post step summary as PR check annotation
     steps:
-      - name: "Check out code"
+      - name: Check out code
         uses: actions/checkout@v5
-        with: 
-          fetch-depth: 0
+        with:
+          fetch-depth: 0   # full history so svu can walk commits
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      
-      - name: release test
-        uses: goreleaser/goreleaser-action@v6
+
+      # Compute the next semantic version from conventional commits.
+      # svu is read-only here: it only prints the next version string.
+      # No tag is created or pushed — that is left to the real release workflow.
+      - name: Compute next version (dry-run)
+        id: next-version
+        run: |
+          go install github.com/caarlos0/svu/v3@v3.2.3
+          NEXT=$(svu next --tag.mode=all 2>/dev/null || svu current)
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "### 🔖 Next release version (preview): \`${NEXT}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      # Run the full goreleaser release pipeline in snapshot mode via the
+      # reusable projectdiscovery/actions/goreleaser action.
+      # release: 'true'  → uses 'release --skip=validate --clean'
+      # args: '--snapshot' → appended, so nothing is published or tagged.
+      - name: Goreleaser snapshot release
+        uses: projectdiscovery/actions/goreleaser@v1.29.4
         with:
-          args: "release --clean --snapshot"
-          version: latest
-          workdir: .
+          release: 'true'
+          args: '--snapshot'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # Tell goreleaser which version this snapshot represents so the
+          # artifact names match what the real release would produce.
+          GORELEASER_CURRENT_TAG: "${{ steps.next-version.outputs.version }}"
+
+      - name: Summarise artifacts
+        if: success()
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### Snapshot artifacts built for \`${{ steps.next-version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -d dist ]; then
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            ls dist/*.zip dist/*.tar.gz dist/checksums.txt 2>/dev/null | xargs -I{} basename {} >> "$GITHUB_STEP_SUMMARY" || ls dist/ >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> ✅ No tags were pushed. No artifacts were published. This is a dry-run only." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

This PR adds the **actual release automation flow** for proxify, built on the reusable pieces already merged in [`projectdiscovery/actions`](https://github.com/projectdiscovery/actions).

## Files changed

1. **`.github/workflows/release-tag.yml`** — new workflow
   - Runs automatically on pushes to `main`
   - Uses `projectdiscovery/actions/svu-next@v1.29.4` to compute and create the next release tag
   - Supports manual `workflow_dispatch` controls for:
     - `ref`
     - `dry-run`
     - `always-bump`
     - `prerelease`
     - `metadata`
     - `tag-prefix`
     - `v0`

2. **`.github/workflows/release-binary.yml`** — production publish workflow
   - Still publishes on `push.tags: v*`
   - Switched from direct `goreleaser/goreleaser-action` usage to `projectdiscovery/actions/goreleaser@v1.29.4`
   - Adds guarded manual `workflow_dispatch` support with:
     - required `tag`
     - optional `ref`
     - `announce` toggle
     - extra `goreleaser-args`
   - Rejects manual runs that do not target an explicit `v*` tag
   - Sets `GORELEASER_CURRENT_TAG` explicitly for manual publish runs

## Resulting release flow

### Automatic path

1. Merge to `main`
2. `release-tag.yml` computes the next version and pushes the tag
3. Tag push triggers `release-binary.yml`
4. `release-binary.yml` publishes the GitHub release and binaries via GoReleaser

### Manual path

- Run **Create Release Tag** to preview or create the next tag from any ref
- Run **Release Binary** against an explicit existing tag when you need a controlled manual publish or re-run

## Guardrails kept in the real workflow

- PRs do **not** publish anything
- Manual publish requires an explicit `v*` tag
- Announcements can be disabled for manual runs
- Tag creation and binary publishing stay separated into two workflows, so tag creation remains the release gate

## Why this uses `projectdiscovery/actions`

The release safety and shared behavior now live centrally in the actions repo:
- `svu-next` handles next-version calculation and optional dry-run tagging
- `goreleaser` wraps the shared GoReleaser invocation

That keeps proxify as a thin consumer and makes rollout to other repos straightforward.